### PR TITLE
Avoid truncating utf-8 strings in the middle of a codepoint in

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -97,9 +97,13 @@ impl fmt::Debug for Document {
             .field_values
             .iter()
             .map(|(field_name, field_values)| {
-                let mut values_str =
-                    field_values.iter().map(value_to_string).join(",");
-                values_str.truncate(10);
+                let values_str: String = field_values
+                    .iter()
+                    .map(value_to_string)
+                    .join(",")
+                    .chars()
+                    .take(10)
+                    .collect();
                 format!("{}=[{}]", field_name, values_str)
             })
             .join(",");

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -301,6 +301,10 @@ class TestDocument(object):
         doc = tantivy.Document(name="Bill", reference=[1, 2])
         assert repr(doc) == "Document(name=[Bill],reference=[1,2])"
 
+    def test_document_repr_utf8(self):
+        doc = tantivy.Document(name="野菜食べないとやばい", reference=[1, 2])
+        assert repr(doc) == "Document(name=[野菜食べないとやばい],reference=[1,2])"
+
     def test_document_with_facet(self):
         doc = tantivy.Document()
         facet = tantivy.Facet.from_string("/europe/france")


### PR DESCRIPTION
`Document::__repr__`

Closes #24