### PR TITLE
Adding float64 support, document level boosting, and facet collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 tantivy.so
 tantivy/tantivy.cpython*.so
 tantivy.egg-info/
+4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
-requires = ["maturin"]
+requires = ["maturin==0.13.0"]
 build-backend = "maturin"
 
 [project]
 name = "tantivy"
 requires-python = ">=3.7"
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-maturin
+maturin==0.13.0
 pytest>=4.0

--- a/src/facet.rs
+++ b/src/facet.rs
@@ -48,7 +48,7 @@ impl Facet {
     #[classmethod]
     fn from_string(_cls: &PyType, facet_string: &str) -> Facet {
         Facet {
-            inner: schema::Facet::from(facet_string),
+            inner: schema::Facet::from_text(facet_string).unwrap(),
         }
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -346,7 +346,16 @@ impl Index {
         } else {
             for (field, field_entry) in self.index.schema().fields() {
                 if field_entry.is_indexed() {
-                    default_fields.push(field);
+
+                    match field_entry.field_type() {
+                        tv::schema::FieldType::Facet(_) => {
+                            // facets aren't suited for default fields
+                        },
+                        _ => {
+                            default_fields.push(field);
+                        },
+                    }
+
                 }
             }
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -314,10 +314,12 @@ impl Index {
     ///         field is specified in the query.
     ///
     #[args(reload_policy = "RELOAD_POLICY")]
+    #[args(conjunction_by_default = false)]
     pub fn parse_query(
         &self,
         query: &str,
         default_field_names: Option<Vec<String>>,
+        conjunction_by_default: bool,
     ) -> PyResult<Query> {
         let mut default_fields = vec![];
         let schema = self.index.schema();
@@ -348,8 +350,13 @@ impl Index {
                 }
             }
         }
-        let parser =
+        let mut parser =
             tv::query::QueryParser::for_index(&self.index, default_fields);
+    
+        if conjunction_by_default {
+            parser.set_conjunction_by_default();
+        }
+
         let query = parser.parse_query(query).map_err(to_pyerr)?;
 
         Ok(Query { inner: query })

--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -2,7 +2,7 @@
 
 use pyo3::{exceptions, prelude::*};
 
-use tantivy::schema;
+use tantivy::schema::{self, FacetOptions};
 
 use crate::schema::Schema;
 use std::sync::{Arc, RwLock};
@@ -123,6 +123,50 @@ impl SchemaBuilder {
 
         if let Some(builder) = builder.write().unwrap().as_mut() {
             builder.add_i64_field(name, opts);
+        } else {
+            return Err(exceptions::PyValueError::new_err(
+                "Schema builder object isn't valid anymore.",
+            ));
+        }
+        Ok(self.clone())
+    }
+
+    /// Add a new float64 field to the schema.
+    /// Note: When adding value to the index, make sure that it is type-casted to float
+    /// Adding integers or other values may produce false result
+    ///
+    /// Args:
+    ///     name (str): The name of the field.
+    ///     stored (bool, optional): If true sets the field as stored, the
+    ///         content of the field can be later restored from a Searcher.
+    ///         Defaults to False.
+    ///     indexed (bool, optional): If true sets the field to be indexed.
+    ///     fast (str, optional): Set the f64 options as a single-valued fast
+    ///         field. Fast fields are designed for random access. Access time
+    ///         are similar to a random lookup in an array. If more than one
+    ///         value is associated to a fast field, only the last one is kept.
+    ///         Can be one of 'single' or 'multi'. If this is set to 'single,
+    ///         the document must have exactly one value associated to the
+    ///         document. If this is set to 'multi', the document can have any
+    ///         number of values associated to the document. Defaults to None,
+    ///         which disables this option.
+    ///
+    /// Returns the associated field handle.
+    /// Raises a ValueError if there was an error with the field creation.
+    #[args(stored = false, indexed = false)]
+    fn add_float_field(
+        &mut self,
+        name: &str,
+        stored: bool,
+        indexed: bool,
+        fast: Option<&str>,
+    ) -> PyResult<Self> {
+        let builder = &mut self.builder;
+
+        let opts = SchemaBuilder::build_float_option(stored, indexed, fast)?;
+
+        if let Some(builder) = builder.write().unwrap().as_mut() {
+            builder.add_f64_field(name, opts);
         } else {
             return Err(exceptions::PyValueError::new_err(
                 "Schema builder object isn't valid anymore.",
@@ -267,13 +311,14 @@ impl SchemaBuilder {
     /// Add a Facet field to the schema.
     /// Args:
     ///     name (str): The name of the field.
+    #[args(stored = false, indexed = false)]
     fn add_facet_field(&mut self, name: &str) -> PyResult<Self> {
         let builder = &mut self.builder;
 
         if let Some(builder) = builder.write().unwrap().as_mut() {
-            builder.add_facet_field(name, INDEXED);
+            builder.add_facet_field(name, FacetOptions::default());
         } else {
-            return Err(exceptions::PyValueError::new_err(
+            return Err(exceptions::PyValueError::new_err( 
                 "Schema builder object isn't valid anymore.",
             ));
         }
@@ -320,6 +365,39 @@ impl SchemaBuilder {
 
 impl SchemaBuilder {
     fn build_int_option(
+        stored: bool,
+        indexed: bool,
+        fast: Option<&str>,
+    ) -> PyResult<schema::NumericOptions> {
+        let opts = schema::NumericOptions::default();
+
+        let opts = if stored { opts.set_stored() } else { opts };
+        let opts = if indexed { opts.set_indexed() } else { opts };
+
+        let fast = match fast {
+            Some(f) => {
+                let f = f.to_lowercase();
+                match f.as_ref() {
+                    "single" => Some(schema::Cardinality::SingleValue),
+                    "multi" => Some(schema::Cardinality::MultiValues),
+                    _ => return Err(exceptions::PyValueError::new_err(
+                        "Invalid index option, valid choices are: 'multivalue' and 'singlevalue'"
+                    )),
+                }
+            }
+            None => None,
+        };
+
+        let opts = if let Some(f) = fast {
+            opts.set_fast(f)
+        } else {
+            opts
+        };
+
+        Ok(opts)
+    }
+
+    fn build_float_option(
         stored: bool,
         indexed: bool,
         fast: Option<&str>,

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -92,6 +92,8 @@ impl Searcher {
     ///         return. Defaults to 10.
     ///     count (bool, optional): Should the number of documents that match
     ///         the query be returned as well. Defaults to true.
+    ///     count_facets_by_field (Field, optional): Return grouped number of
+    ///         documents by the given facet field. Defaults to false
     ///     order_by_field (Field, optional): A schema field that the results
     ///         should be ordered by. The field must be declared as a fast field
     ///         when building the schema. Note, this only works for unsigned


### PR DESCRIPTION
This PR adds a couple of new features that are present in Tantivy core repo, but not exposed in tantivy-py:

## Conjunction by default parameter

By default, tantivy parses queries using OR operator, instead of AND operator. If we want to modify this behavior, we can now set this value when parsing query:

```py
parse_query(text, fields, conjunction_by_default=True)
```

## Floating point support

A new `add_float_field` function is available so that we can add f64 fields.

## Document level boosting 

We can now give priority to certain documents using the new `weight_by_field` parameter:

```py
searcher.search(query, limit, weight_by_field='popularity')
```

TopDocs `tweak_score` is used, and the callback is abstracted away from python code for performance reasons.


## Facet collector

We can now get counts of facets available by specifying the `count_facets_by_field` parameter:

```py
data = searcher.search(query, limit, count_facets_by_field='genre')

print(data.facet_counts)
# prints a dictionary where keys are facets, and values are counts
```
