### PR TITLE
Support pickling of some objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -800,9 +800,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -854,7 +854,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -865,14 +865,24 @@ checksum = "e0b78ccbb160db1556cdb6fd96c50334c5d4ec44dc5e0a968d0a1208fa0efa8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "pythonize"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e35b716d430ace57e2d1b4afb51c9e5b7c46d2bce72926e07f9be6a98ced03e"
+dependencies = [
+ "pyo3",
+ "serde",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -1032,22 +1042,22 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1112,6 +1122,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tantivy"
 version = "0.20.1"
 dependencies = [
@@ -1120,6 +1141,8 @@ dependencies = [
  "itertools",
  "pyo3",
  "pyo3-build-config",
+ "pythonize",
+ "serde",
  "serde_json",
  "tantivy 0.20.2",
 ]
@@ -1313,7 +1336,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1384,7 +1407,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1505,7 +1528,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -1527,7 +1550,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,22 +1042,22 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "serde"
-version = "1.0.174"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.174"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ chrono = "0.4.23"
 tantivy = "0.20.1"
 itertools = "0.10.5"
 futures = "0.3.26"
+pythonize = "0.19.0"
+serde = "~1.0"
 serde_json = "1.0.91"
 
 [dependencies.pyo3]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tantivy = "0.20.1"
 itertools = "0.10.5"
 futures = "0.3.26"
 pythonize = "0.19.0"
-serde = "~1.0.181"
+serde = "1.0"
 serde_json = "1.0.91"
 
 [dependencies.pyo3]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tantivy = "0.20.1"
 itertools = "0.10.5"
 futures = "0.3.26"
 pythonize = "0.19.0"
-serde = "~1.0"
+serde = "~1.0.181"
 serde_json = "1.0.91"
 
 [dependencies.pyo3]

--- a/src/document.rs
+++ b/src/document.rs
@@ -449,7 +449,7 @@ impl<'de> Deserialize<'de> for Document {
     where
         D: Deserializer<'de>,
     {
-        HashMap::<String, Vec<SerdeValue>>::deserialize(deserializer).map(
+        BTreeMap::<String, Vec<SerdeValue>>::deserialize(deserializer).map(
             |field_map| Document {
                 field_values: field_map
                     .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use facet::Facet;
 use index::Index;
 use schema::Schema;
 use schemabuilder::SchemaBuilder;
-use searcher::{DocAddress, Searcher};
+use searcher::{DocAddress, SearchResult, Searcher};
 
 /// Python bindings for the search engine library Tantivy.
 ///
@@ -71,6 +71,7 @@ fn tantivy(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Schema>()?;
     m.add_class::<SchemaBuilder>()?;
     m.add_class::<Searcher>()?;
+    m.add_class::<SearchResult>()?;
     m.add_class::<Document>()?;
     m.add_class::<Index>()?;
     m.add_class::<DocAddress>()?;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,12 +1,14 @@
-use pyo3::{basic::CompareOp, prelude::*};
+use crate::to_pyerr;
+use pyo3::{basic::CompareOp, prelude::*, types::PyTuple};
+use serde::{Deserialize, Serialize};
 use tantivy as tv;
 
 /// Tantivy schema.
 ///
 /// The schema is very strict. To build the schema the `SchemaBuilder` class is
 /// provided.
-#[pyclass(frozen)]
-#[derive(PartialEq)]
+#[pyclass(frozen, module = "tantivy")]
+#[derive(Deserialize, PartialEq, Serialize)]
 pub(crate) struct Schema {
     pub(crate) inner: tv::schema::Schema,
 }
@@ -24,5 +26,25 @@ impl Schema {
             CompareOp::Ne => (self != other).into_py(py),
             _ => py.NotImplemented(),
         }
+    }
+
+    #[staticmethod]
+    fn _internal_from_pythonized(serialized: &PyAny) -> PyResult<Self> {
+        pythonize::depythonize(serialized).map_err(to_pyerr)
+    }
+
+    fn __reduce__<'a>(
+        slf: PyRef<'a, Self>,
+        py: Python<'a>,
+    ) -> PyResult<&'a PyTuple> {
+        let serialized = pythonize::pythonize(py, &*slf).map_err(to_pyerr)?;
+
+        Ok(PyTuple::new(
+            py,
+            [
+                slf.into_py(py).getattr(py, "_internal_from_pythonized")?,
+                PyTuple::new(py, [serialized]).to_object(py),
+            ],
+        ))
     }
 }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -2,6 +2,7 @@
 
 use crate::{document::Document, query::Query, to_pyerr};
 use pyo3::{basic::CompareOp, exceptions::PyValueError, prelude::*};
+use serde::{Deserialize, Serialize};
 use tantivy as tv;
 use tantivy::collector::{Count, MultiCollector, TopDocs};
 
@@ -13,9 +14,11 @@ pub(crate) struct Searcher {
     pub(crate) inner: tv::Searcher,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Deserialize, FromPyObject, PartialEq, Serialize)]
 enum Fruit {
+    #[pyo3(transparent)]
     Score(f32),
+    #[pyo3(transparent)]
     Order(u64),
 }
 
@@ -37,8 +40,8 @@ impl ToPyObject for Fruit {
     }
 }
 
-#[pyclass(frozen)]
-#[derive(Clone, PartialEq)]
+#[pyclass(frozen, module = "tantivy")]
+#[derive(Clone, Default, Deserialize, PartialEq, Serialize)]
 /// Object holding a results successful search.
 pub(crate) struct SearchResult {
     hits: Vec<(Fruit, DocAddress)>,
@@ -50,6 +53,19 @@ pub(crate) struct SearchResult {
 
 #[pymethods]
 impl SearchResult {
+    #[new]
+    fn new(
+        py: Python,
+        hits: Vec<(PyObject, DocAddress)>,
+        count: Option<usize>,
+    ) -> PyResult<Self> {
+        let hits = hits
+            .iter()
+            .map(|(f, d)| Ok((f.extract(py)?, d.clone())))
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(Self { hits, count })
+    }
+
     fn __repr__(&self) -> PyResult<String> {
         if let Some(count) = self.count {
             Ok(format!(
@@ -72,6 +88,13 @@ impl SearchResult {
             CompareOp::Ne => (self != other).into_py(py),
             _ => py.NotImplemented(),
         }
+    }
+
+    fn __getnewargs__(
+        &self,
+        py: Python,
+    ) -> PyResult<(Vec<(PyObject, DocAddress)>, Option<usize>)> {
+        Ok((self.hits(py)?, self.count))
     }
 
     #[getter]
@@ -214,8 +237,8 @@ impl Searcher {
 /// It consists in an id identifying its segment, and its segment-local DocId.
 /// The id used for the segment is actually an ordinal in the list of segment
 /// hold by a Searcher.
-#[pyclass(frozen)]
-#[derive(Clone, Debug, PartialEq)]
+#[pyclass(frozen, module = "tantivy")]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub(crate) struct DocAddress {
     pub(crate) segment_ord: tv::SegmentOrdinal,
     pub(crate) doc: tv::DocId,
@@ -223,6 +246,11 @@ pub(crate) struct DocAddress {
 
 #[pymethods]
 impl DocAddress {
+    #[new]
+    fn new(segment_ord: tv::SegmentOrdinal, doc: tv::DocId) -> Self {
+        DocAddress { segment_ord, doc }
+    }
+
     /// The segment ordinal is an id identifying the segment hosting the
     /// document. It is only meaningful, in the context of a searcher.
     #[getter]
@@ -247,6 +275,10 @@ impl DocAddress {
             CompareOp::Ne => (self != other).into_py(py),
             _ => py.NotImplemented(),
         }
+    }
+
+    fn __getnewargs__(&self) -> PyResult<(tv::SegmentOrdinal, tv::DocId)> {
+        Ok((self.segment_ord, self.doc))
     }
 }
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -1,5 +1,7 @@
 from io import BytesIO
+
 import copy
+import datetime
 import tantivy
 import pickle
 import pytest
@@ -567,8 +569,6 @@ class TestDocument(object):
         assert doc.to_dict() == {"name": ["Bill"], "reference": [1, 2]}
 
     def test_document_with_date(self):
-        import datetime
-
         date = datetime.datetime(2019, 8, 12, 13, 0, 0)
         doc = tantivy.Document(name="Bill", date=date)
         assert doc["date"][0] == date
@@ -618,7 +618,18 @@ class TestDocument(object):
         assert doc2 == doc3
 
     def test_document_pickle(self):
-        orig = Document(id=1, title="hello world!")
+        orig = Document()
+        orig.add_unsigned("unsigned", 1)
+        orig.add_integer("integer", 5)
+        orig.add_float("float", 1.0)
+        orig.add_date("birth", datetime.datetime(2019, 8, 12, 13, 0, 5))
+        orig.add_text("title", "hello world!")
+        orig.add_json("json", '{"a": 1, "b": 2}')
+        orig.add_bytes("bytes", b"abc")
+
+        facet = tantivy.Facet.from_string("/europe/france")
+        orig.add_facet("facet", facet)
+
         pickled = pickle.loads(pickle.dumps(orig))
 
         assert orig == pickled
@@ -763,6 +774,7 @@ def test_facet_pickle():
     pickled = pickle.loads(pickle.dumps(orig))
 
     assert orig == pickled
+
 
 def test_doc_address_pickle():
     orig = tantivy.DocAddress(42, 123)


### PR DESCRIPTION
Fixes #96, supporting serialization via `pythonize`.

The (personal) use-case here is to be able to send types across process boundaries (i.e. large batches of `Document`s across to a process pool for some kind of processing).