### PR TITLE
Add support for booleans in schemas and docs

### DIFF
--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -98,11 +98,12 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the numeric options as a single-valued
-    ///         fast field. Fast fields are designed for random access. Access
-    ///         time are similar to a random lookup in an array. If more than
-    ///         one value is associated to a fast field, only the last one is
-    ///         kept.
+    ///     fast (str, optional): Set the numeric options as a fast field. A
+    ///         fast field is a column-oriented fashion storage for tantivy.
+    ///         It is designed for the fast random access of some document
+    ///         fields given a document id. Read access performance is
+    ///         comparable to that of an array lookup. If more than one value
+    ///         is associated with a fast field, only the last one is kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -136,11 +137,12 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the numeric options as a single-valued
-    ///         fast field. Fast fields are designed for random access. Access
-    ///         time are similar to a random lookup in an array. If more than
-    ///         one value is associated to a fast field, only the last one is
-    ///         kept.
+    ///     fast (str, optional): Set the numeric options as a fast field. A
+    ///         fast field is a column-oriented fashion storage for tantivy.
+    ///         It is designed for the fast random access of some document
+    ///         fields given a document id. Read access performance is
+    ///         comparable to that of an array lookup. If more than one value
+    ///         is associated with a fast field, only the last one is kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -174,11 +176,12 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the numeric options as a single-valued
-    ///         fast field. Fast fields are designed for random access. Access
-    ///         time are similar to a random lookup in an array. If more than
-    ///         one value is associated to a fast field, only the last one is
-    ///         kept.
+    ///     fast (str, optional): Set the numeric options as a fast field. A
+    ///         fast field is a column-oriented fashion storage for tantivy.
+    ///         It is designed for the fast random access of some document
+    ///         fields given a document id. Read access performance is
+    ///         comparable to that of an array lookup. If more than one value
+    ///         is associated with a fast field, only the last one is kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -212,11 +215,12 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the numeric options as a single-valued
-    ///         fast field. Fast fields are designed for random access. Access
-    ///         time are similar to a random lookup in an array. If more than
-    ///         one value is associated to a fast field, only the last one is
-    ///         kept.
+    ///     fast (str, optional): Set the numeric options as a fast field. A
+    ///         fast field is a column-oriented fashion storage for tantivy.
+    ///         It is designed for the fast random access of some document
+    ///         fields given a document id. Read access performance is
+    ///         comparable to that of an array lookup. If more than one value
+    ///         is associated with a fast field, only the last one is kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -250,11 +254,12 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the date options as a single-valued
-    ///         fast field. Fast fields are designed for random access. Access
-    ///         time are similar to a random lookup in an array. If more than
-    ///         one value is associated to a fast field, only the last one is
-    ///         kept.
+    ///     fast (str, optional): Set the date options as a fast field. A fast
+    ///         field is a column-oriented fashion storage for tantivy. It is
+    ///         designed for the fast random access of some document fields
+    ///         given a document id. Read access performance is comparable to
+    ///         that of an array lookup. If more than one value is associated
+    ///         with a fast field, only the last one is kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.

--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -101,9 +101,7 @@ impl SchemaBuilder {
     ///     fast (str, optional): Set the numeric options as a fast field. A
     ///         fast field is a column-oriented fashion storage for tantivy.
     ///         It is designed for the fast random access of some document
-    ///         fields given a document id. Read access performance is
-    ///         comparable to that of an array lookup. If more than one value
-    ///         is associated with a fast field, only the last one is kept.
+    ///         fields given a document id.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -140,9 +138,7 @@ impl SchemaBuilder {
     ///     fast (str, optional): Set the numeric options as a fast field. A
     ///         fast field is a column-oriented fashion storage for tantivy.
     ///         It is designed for the fast random access of some document
-    ///         fields given a document id. Read access performance is
-    ///         comparable to that of an array lookup. If more than one value
-    ///         is associated with a fast field, only the last one is kept.
+    ///         fields given a document id.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -179,9 +175,7 @@ impl SchemaBuilder {
     ///     fast (str, optional): Set the numeric options as a fast field. A
     ///         fast field is a column-oriented fashion storage for tantivy.
     ///         It is designed for the fast random access of some document
-    ///         fields given a document id. Read access performance is
-    ///         comparable to that of an array lookup. If more than one value
-    ///         is associated with a fast field, only the last one is kept.
+    ///         fields given a document id.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -218,9 +212,7 @@ impl SchemaBuilder {
     ///     fast (str, optional): Set the numeric options as a fast field. A
     ///         fast field is a column-oriented fashion storage for tantivy.
     ///         It is designed for the fast random access of some document
-    ///         fields given a document id. Read access performance is
-    ///         comparable to that of an array lookup. If more than one value
-    ///         is associated with a fast field, only the last one is kept.
+    ///         fields given a document id.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -257,9 +249,7 @@ impl SchemaBuilder {
     ///     fast (str, optional): Set the date options as a fast field. A fast
     ///         field is a column-oriented fashion storage for tantivy. It is
     ///         designed for the fast random access of some document fields
-    ///         given a document id. Read access performance is comparable to
-    ///         that of an array lookup. If more than one value is associated
-    ///         with a fast field, only the last one is kept.
+    ///         given a document id.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.

--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -98,15 +98,11 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the u64 options as a single-valued fast
-    ///         field. Fast fields are designed for random access. Access time
-    ///         are similar to a random lookup in an array. If more than one
-    ///         value is associated to a fast field, only the last one is kept.
-    ///         Can be one of 'single' or 'multi'. If this is set to 'single,
-    ///         the document must have exactly one value associated to the
-    ///         document. If this is set to 'multi', the document can have any
-    ///         number of values associated to the document. Defaults to None,
-    ///         which disables this option.
+    ///     fast (str, optional): Set the numeric options as a single-valued
+    ///         fast field. Fast fields are designed for random access. Access
+    ///         time are similar to a random lookup in an array. If more than
+    ///         one value is associated to a fast field, only the last one is
+    ///         kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -132,6 +128,22 @@ impl SchemaBuilder {
         Ok(self.clone())
     }
 
+    /// Add a new float field to the schema.
+    ///
+    /// Args:
+    ///     name (str): The name of the field.
+    ///     stored (bool, optional): If true sets the field as stored, the
+    ///         content of the field can be later restored from a Searcher.
+    ///         Defaults to False.
+    ///     indexed (bool, optional): If true sets the field to be indexed.
+    ///     fast (str, optional): Set the numeric options as a single-valued
+    ///         fast field. Fast fields are designed for random access. Access
+    ///         time are similar to a random lookup in an array. If more than
+    ///         one value is associated to a fast field, only the last one is
+    ///         kept.
+    ///
+    /// Returns the associated field handle.
+    /// Raises a ValueError if there was an error with the field creation.
     #[pyo3(signature = (name, stored = false, indexed = false, fast = false))]
     fn add_float_field(
         &mut self,
@@ -162,15 +174,11 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the u64 options as a single-valued fast
-    ///         field. Fast fields are designed for random access. Access time
-    ///         are similar to a random lookup in an array. If more than one
-    ///         value is associated to a fast field, only the last one is kept.
-    ///         Can be one of 'single' or 'multi'. If this is set to 'single,
-    ///         the document must have exactly one value associated to the
-    ///         document. If this is set to 'multi', the document can have any
-    ///         number of values associated to the document. Defaults to None,
-    ///         which disables this option.
+    ///     fast (str, optional): Set the numeric options as a single-valued
+    ///         fast field. Fast fields are designed for random access. Access
+    ///         time are similar to a random lookup in an array. If more than
+    ///         one value is associated to a fast field, only the last one is
+    ///         kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -204,15 +212,11 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the bool options as a single-valued fast
-    ///         field. Fast fields are designed for random access. Access time
-    ///         are similar to a random lookup in an array. If more than one
-    ///         value is associated to a fast field, only the last one is kept.
-    ///         Can be one of 'single' or 'multi'. If this is set to 'single,
-    ///         the document must have exactly one value associated to the
-    ///         document. If this is set to 'multi', the document can have any
-    ///         number of values associated to the document. Defaults to None,
-    ///         which disables this option.
+    ///     fast (str, optional): Set the numeric options as a single-valued
+    ///         fast field. Fast fields are designed for random access. Access
+    ///         time are similar to a random lookup in an array. If more than
+    ///         one value is associated to a fast field, only the last one is
+    ///         kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -246,15 +250,11 @@ impl SchemaBuilder {
     ///         content of the field can be later restored from a Searcher.
     ///         Defaults to False.
     ///     indexed (bool, optional): If true sets the field to be indexed.
-    ///     fast (str, optional): Set the u64 options as a single-valued fast
-    ///         field. Fast fields are designed for random access. Access time
-    ///         are similar to a random lookup in an array. If more than one
-    ///         value is associated to a fast field, only the last one is kept.
-    ///         Can be one of 'single' or 'multi'. If this is set to 'single',
-    ///         the document must have exactly one value associated to the
-    ///         document. If this is set to 'multi', the document can have any
-    ///         number of values associated to the document. Defaults to None,
-    ///         which disables this option.
+    ///     fast (str, optional): Set the date options as a single-valued
+    ///         fast field. Fast fields are designed for random access. Access
+    ///         time are similar to a random lookup in an array. If more than
+    ///         one value is associated to a fast field, only the last one is
+    ///         kept.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.

--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -196,6 +196,48 @@ impl SchemaBuilder {
         Ok(self.clone())
     }
 
+    /// Add a new boolean field to the schema.
+    ///
+    /// Args:
+    ///     name (str): The name of the field.
+    ///     stored (bool, optional): If true sets the field as stored, the
+    ///         content of the field can be later restored from a Searcher.
+    ///         Defaults to False.
+    ///     indexed (bool, optional): If true sets the field to be indexed.
+    ///     fast (str, optional): Set the bool options as a single-valued fast
+    ///         field. Fast fields are designed for random access. Access time
+    ///         are similar to a random lookup in an array. If more than one
+    ///         value is associated to a fast field, only the last one is kept.
+    ///         Can be one of 'single' or 'multi'. If this is set to 'single,
+    ///         the document must have exactly one value associated to the
+    ///         document. If this is set to 'multi', the document can have any
+    ///         number of values associated to the document. Defaults to None,
+    ///         which disables this option.
+    ///
+    /// Returns the associated field handle.
+    /// Raises a ValueError if there was an error with the field creation.
+    #[pyo3(signature = (name, stored = false, indexed = false, fast = false))]
+    fn add_boolean_field(
+        &mut self,
+        name: &str,
+        stored: bool,
+        indexed: bool,
+        fast: bool,
+    ) -> PyResult<Self> {
+        let builder = &mut self.builder;
+
+        let opts = SchemaBuilder::build_numeric_option(stored, indexed, fast)?;
+
+        if let Some(builder) = builder.write().unwrap().as_mut() {
+            builder.add_bool_field(name, opts);
+        } else {
+            return Err(exceptions::PyValueError::new_err(
+                "Schema builder object isn't valid anymore.",
+            ));
+        }
+        Ok(self.clone())
+    }
+
     /// Add a new date field to the schema.
     ///
     /// Args:

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -20,6 +20,7 @@ def schema_numeric_fields():
         SchemaBuilder()
         .add_integer_field("id", stored=True, indexed=True)
         .add_float_field("rating", stored=True, indexed=True)
+        .add_boolean_field("is_good", stored=True, indexed=True)
         .add_text_field("body", stored=True)
         .build()
     )
@@ -86,6 +87,7 @@ def create_index_with_numeric_fields(dir=None):
     doc = Document()
     doc.add_integer("id", 1)
     doc.add_float("rating", 3.5)
+    doc.add_boolean("is_good", True)
     doc.add_text(
         "body",
         (
@@ -99,6 +101,7 @@ def create_index_with_numeric_fields(dir=None):
         {
             "id": 2,
             "rating": 4.5,
+            "is_good": False,
             "body": (
                 "A few miles south of Soledad, the Salinas River drops "
                 "in close to the hillside bank and runs deep and "
@@ -113,7 +116,7 @@ def create_index_with_numeric_fields(dir=None):
                 "sycamores with mottled, white, recumbent limbs and "
                 "branches that arch over the pool"
             ),
-        }
+        },
     )
     writer.add_document(doc)
     writer.commit()


### PR DESCRIPTION
Previously, the bindings did not support adding boolean fields to either the schema or the document. This adds support for it.