### PR TITLE
Fine-tune handling of GIL for search

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -740,7 +740,7 @@ impl Document {
     {
         self.field_values
             .entry(field_name)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(Value::from(value));
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -308,19 +308,13 @@ impl Index {
         Ok(())
     }
 
-    /// Acquires a Searcher from the searcher pool.
+    /// Returns a searcher
     ///
-    /// If no searcher is available during the call, note that
-    /// this call will block until one is made available.
-    ///
-    /// Searcher are automatically released back into the pool when
-    /// they are dropped. If you observe this function to block forever
-    /// you probably should configure the Index to have a larger
-    /// searcher pool, or you are holding references to previous searcher
-    /// for ever.
-    fn searcher(&self, py: Python) -> Searcher {
+    /// This method should be called every single time a search query is performed.
+    /// The same searcher must be used for a given query, as it ensures the use of a consistent segment set.
+    fn searcher(&self) -> Searcher {
         Searcher {
-            inner: py.allow_threads(|| self.reader.searcher()),
+            inner: self.reader.searcher(),
         }
     }
 


### PR DESCRIPTION
The releases GIL during query execution so that multiple queries can make progress in parallel but it does not bother releasing (and re-acquiring) the GIL for searcher acquisition as there is no more searcher pool since Tantivy 0.19.0.