### PR TITLE
Expose `is_valid_field_name()` to bindings

### DIFF
--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -41,6 +41,11 @@ impl SchemaBuilder {
         }
     }
 
+    #[staticmethod]
+    fn is_valid_field_name(name: &str) -> bool {
+        schema::is_valid_field_name(name)
+    }
+
     /// Add a new text field to the schema.
     ///
     /// Args:


### PR DESCRIPTION
Adding fields make assertions on this check, but there's nothing that exposes this functionality to the Python bindings.

The underlying library should probably return a `Result<>` instead, but that's out of scope here.