### PR TITLE
Change to action `dtolnay/rust-toolchain` and 1.73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,9 @@ jobs:
         uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089
 
       - name: Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
-          toolchain: stable
-          components: rustfmt
+            components: rustfmt
 
       - name: Check Formatting
         run: cargo fmt --check
@@ -73,9 +72,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8  # 2.7.1
       - run: python3 -m pip install nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
         uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089
 
       - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@1.73.0
+        uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
         with:
-            components: rustfmt
+          toolchain: 1.73.0
+          components: rustfmt
 
       - name: Check Formatting
         run: cargo fmt --check
@@ -72,7 +73,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: dtolnay/rust-toolchain@1.73.0
+      - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: 1.73.0
 
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8  # 2.7.1
       - run: python3 -m pip install nox

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -147,7 +147,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: dtolnay/rust-toolchain@1.73.0
+      - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: 1.73.0
 
       - name: Set up Python 3.8
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -147,10 +147,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@1.73.0
 
       - name: Set up Python 3.8
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "base64",
  "chrono",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.73.0"


### PR DESCRIPTION
This changes to the `dtolnay/rust-toolchain` action because `actions-rs` [is deprecated](https://github.com/actions-rs/toolchain/issues/216). It also pins the rust compiler to 1.73.0 because of an [internal compiler error in 1.74](https://github.com/rust-lang/rust/issues/117976).