### PR TITLE
Expose tantivy's TermQuery

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,5 @@
-use pyo3::prelude::*;
+use crate::{make_term, Schema};
+use pyo3::{exceptions, prelude::*, types::PyAny};
 use tantivy as tv;
 
 /// Tantivy's Query
@@ -18,4 +19,37 @@ impl Query {
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!("Query({:?})", self.get()))
     }
+
+    /// Construct a Tantivy's TermQuery
+    #[staticmethod]
+    #[pyo3(signature = (schema, field_name, field_value, index_option = "position"))]
+    pub(crate) fn new_term_query(
+        schema: &Schema,
+        field_name: &str,
+        field_value: &PyAny,
+        index_option: &str,
+    ) -> PyResult<Query> {
+        make_term_query(schema, field_name, field_value, index_option)
+    }
+}
+
+fn make_term_query(
+    schema: &Schema,
+    field_name: &str,
+    field_value: &PyAny,
+    index_option: &str,
+) -> PyResult<Query> {
+    let term = make_term(&schema.inner, field_name, field_value)?;
+    let index_option = match index_option {
+        "position" => tv::schema::IndexRecordOption::WithFreqsAndPositions,
+        "freq" => tv::schema::IndexRecordOption::WithFreqs,
+        "basic" => tv::schema::IndexRecordOption::Basic,
+        _ => return Err(exceptions::PyValueError::new_err(
+            "Invalid index option, valid choices are: 'basic', 'freq' and 'position'"
+        ))
+    };
+    let inner = tv::query::TermQuery::new(term, index_option);
+    Ok(Query {
+        inner: Box::new(inner),
+    })
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -29,27 +29,18 @@ impl Query {
         field_value: &PyAny,
         index_option: &str,
     ) -> PyResult<Query> {
-        make_term_query(schema, field_name, field_value, index_option)
+        let term = make_term(&schema.inner, field_name, field_value)?;
+        let index_option = match index_option {
+            "position" => tv::schema::IndexRecordOption::WithFreqsAndPositions,
+            "freq" => tv::schema::IndexRecordOption::WithFreqs,
+            "basic" => tv::schema::IndexRecordOption::Basic,
+            _ => return Err(exceptions::PyValueError::new_err(
+                "Invalid index option, valid choices are: 'basic', 'freq' and 'position'"
+            ))
+        };
+        let inner = tv::query::TermQuery::new(term, index_option);
+        Ok(Query {
+            inner: Box::new(inner),
+        })
     }
-}
-
-fn make_term_query(
-    schema: &Schema,
-    field_name: &str,
-    field_value: &PyAny,
-    index_option: &str,
-) -> PyResult<Query> {
-    let term = make_term(&schema.inner, field_name, field_value)?;
-    let index_option = match index_option {
-        "position" => tv::schema::IndexRecordOption::WithFreqsAndPositions,
-        "freq" => tv::schema::IndexRecordOption::WithFreqs,
-        "basic" => tv::schema::IndexRecordOption::Basic,
-        _ => return Err(exceptions::PyValueError::new_err(
-            "Invalid index option, valid choices are: 'basic', 'freq' and 'position'"
-        ))
-    };
-    let inner = tv::query::TermQuery::new(term, index_option);
-    Ok(Query {
-        inner: Box::new(inner),
-    })
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -23,7 +23,7 @@ impl Query {
     /// Construct a Tantivy's TermQuery
     #[staticmethod]
     #[pyo3(signature = (schema, field_name, field_value, index_option = "position"))]
-    pub(crate) fn new_term_query(
+    pub(crate) fn term_query(
         schema: &Schema,
         field_name: &str,
         field_value: &PyAny,

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -189,7 +189,9 @@ class Document:
 
 
 class Query:
-    pass
+    @staticmethod
+    def new_term_query(schema: Schema, field_name: str, field_value: Any, index_option: str = "position") -> Query:
+        pass
 
 
 class Order(Enum):

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -190,7 +190,7 @@ class Document:
 
 class Query:
     @staticmethod
-    def new_term_query(schema: Schema, field_name: str, field_value: Any, index_option: str = "position") -> Query:
+    def term_query(schema: Schema, field_name: str, field_value: Any, index_option: str = "position") -> Query:
         pass
 
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -7,7 +7,7 @@ import tantivy
 import pickle
 import pytest
 import tantivy
-from tantivy import Document, Index, SchemaBuilder, SnippetGenerator
+from tantivy import Document, Index, SchemaBuilder, SnippetGenerator, Query
 
 
 def schema():
@@ -925,3 +925,15 @@ class TestSnippets(object):
             assert first.end == 23
             html_snippet = snippet.to_html()
             assert html_snippet == "The Old Man and the <b>Sea</b>"
+
+
+class TestQuery(object):
+    def test_term_query(self, ram_index):
+        index = ram_index
+        query = Query.new_term_query(index.schema, "title", "sea")
+
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+        _, doc_address = result.hits[0]
+        searched_doc = index.searcher().doc(doc_address)
+        assert searched_doc["title"] == ["The Old Man and the Sea"]

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -930,7 +930,7 @@ class TestSnippets(object):
 class TestQuery(object):
     def test_term_query(self, ram_index):
         index = ram_index
-        query = Query.new_term_query(index.schema, "title", "sea")
+        query = Query.term_query(index.schema, "title", "sea")
 
         result = index.searcher().search(query, 10)
         assert len(result.hits) == 1


### PR DESCRIPTION
This may relate to #20.

This exposes Tantivy's `TermQuery` to tantivy-py.
I also noticed #53, but it seems incomplete and stale for a while.

- Add `Query.new_term_query()` method with proper type hints.
- Add a test method for TermQuery.