### PR TITLE
chore: fix module namespace

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -463,7 +463,7 @@ impl<'a> From<&'a Value> for BorrowedSerdeValue<'a> {
 ///     ...     {"unsigned": 1000, "signed": -5, "float": 0.4},
 ///     ...     schema,
 ///     ... )
-#[pyclass(module = "tantivy")]
+#[pyclass(module = "tantivy.tantivy")]
 #[derive(Clone, Default, PartialEq)]
 pub(crate) struct Document {
     pub(crate) field_values: BTreeMap<String, Vec<Value>>,

--- a/src/facet.rs
+++ b/src/facet.rs
@@ -16,7 +16,7 @@ use tantivy::schema;
 /// implicitely imply that a document belonging to a facet also belongs to the
 /// ancestor of its facet. In the example above, /electronics/tv_and_video/
 /// and /electronics.
-#[pyclass(frozen, module = "tantivy")]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 #[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub(crate) struct Facet {
     pub(crate) inner: schema::Facet,

--- a/src/index.rs
+++ b/src/index.rs
@@ -27,7 +27,7 @@ const RELOAD_POLICY: &str = "commit";
 ///
 /// To create an IndexWriter first create an Index and call the writer() method
 /// on the index object.
-#[pyclass]
+#[pyclass(module = "tantivy.tantivy")]
 pub(crate) struct IndexWriter {
     inner_index_writer: Option<tv::IndexWriter>,
     schema: tv::schema::Schema,
@@ -200,7 +200,7 @@ impl IndexWriter {
 ///
 /// If an index already exists it will be opened and reused. Raises OSError
 /// if there was a problem during the opening or creation of the index.
-#[pyclass]
+#[pyclass(module = "tantivy.tantivy")]
 pub(crate) struct Index {
     pub(crate) index: tv::Index,
     reader: tv::IndexReader,

--- a/src/parser_error.rs
+++ b/src/parser_error.rs
@@ -82,7 +82,7 @@ impl QueryParserErrorIntoPy for tv::query::QueryParserError {
 }
 
 /// Error in the query syntax.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct SyntaxError {
     message: String,
 }
@@ -131,7 +131,7 @@ impl TryFrom<tv::query::QueryParserError> for SyntaxError {
 }
 
 /// This query is unsupported.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct UnsupportedQueryError {
     message: String,
 }
@@ -180,7 +180,7 @@ impl TryFrom<tv::query::QueryParserError> for UnsupportedQueryError {
 }
 
 /// The query references a field that is not in the schema.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub struct FieldDoesNotExistError {
     field: String,
 }
@@ -230,7 +230,7 @@ impl TryFrom<tv::query::QueryParserError> for FieldDoesNotExistError {
 }
 
 /// The query contains a term for a `u64` or `i64`-field, but the value is neither.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct ExpectedIntError {
     parse_int_error: ParseIntError,
 }
@@ -294,7 +294,7 @@ impl TryFrom<tv::query::QueryParserError> for ExpectedIntError {
 }
 
 /// The query contains a term for a bytes field, but the value is not valid base64.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct ExpectedBase64Error {
     decode_error: base64::DecodeError,
 }
@@ -393,7 +393,7 @@ impl TryFrom<tv::query::QueryParserError> for ExpectedBase64Error {
 }
 
 /// The query contains a term for a `f64`-field, but the value is not a f64.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct ExpectedFloatError {
     parse_float_error: ParseFloatError,
 }
@@ -437,7 +437,7 @@ impl TryFrom<tv::query::QueryParserError> for ExpectedFloatError {
 }
 
 /// The query contains a term for a `bool`-field, but the value is not a bool.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct ExpectedBoolError {
     parse_bool_error: ParseBoolError,
 }
@@ -481,7 +481,7 @@ impl TryFrom<tv::query::QueryParserError> for ExpectedBoolError {
 }
 
 /// It is forbidden queries that are only "excluding". (e.g. -title:pop)
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct AllButQueryForbiddenError;
 
 #[pymethods]
@@ -521,7 +521,7 @@ impl TryFrom<tv::query::QueryParserError> for AllButQueryForbiddenError {
 }
 
 /// If no default field is declared, running a query without any field specified is forbbidden.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct NoDefaultFieldDeclaredError;
 
 #[pymethods]
@@ -561,7 +561,7 @@ impl TryFrom<tv::query::QueryParserError> for NoDefaultFieldDeclaredError {
 }
 
 /// The field searched for is not declared as indexed in the schema.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct FieldNotIndexedError {
     field: String,
 }
@@ -609,7 +609,7 @@ impl TryFrom<tv::query::QueryParserError> for FieldNotIndexedError {
 }
 
 /// A phrase query was requested for a field that does not have any positions indexed.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct FieldDoesNotHavePositionsIndexedError {
     field: String,
 }
@@ -668,7 +668,7 @@ impl TryFrom<tv::query::QueryParserError>
 }
 
 /// A phrase-prefix query requires at least two terms
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct PhrasePrefixRequiresAtLeastTwoTermsError {
     /// The phrase which triggered the issue.
     phrase: String,
@@ -736,7 +736,7 @@ impl TryFrom<tv::query::QueryParserError>
 }
 
 /// The tokenizer for the given field is unknown.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct UnknownTokenizerError {
     /// The name of the tokenizer.
     tokenizer: String,
@@ -799,7 +799,7 @@ impl TryFrom<tv::query::QueryParserError> for UnknownTokenizerError {
 
 /// The query contains a range query with a phrase as one of the bounds. Only terms can be used as
 /// bounds.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct RangeMustNotHavePhraseError;
 
 #[pymethods]
@@ -839,7 +839,7 @@ impl TryFrom<tv::query::QueryParserError> for RangeMustNotHavePhraseError {
 }
 
 /// The format for the date field is not RFC 3339 compliant.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct DateFormatError {
     // Keep around the entire `QueryParserError` to avoid importing the `time` crate.
     inner: tv::query::QueryParserError,
@@ -884,7 +884,7 @@ impl TryFrom<tv::query::QueryParserError> for DateFormatError {
 }
 
 /// The format for the facet field is invalid.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct FacetFormatError {
     facet_parse_error: FacetParseError,
 }
@@ -928,7 +928,7 @@ impl TryFrom<tv::query::QueryParserError> for FacetFormatError {
 }
 
 /// The format for the ip field is invalid.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct IpFormatError {
     addr_parse_error: AddrParseError,
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -3,7 +3,7 @@ use pyo3::{exceptions, prelude::*, types::PyAny};
 use tantivy as tv;
 
 /// Tantivy's Query
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct Query {
     pub(crate) inner: Box<dyn tv::query::Query>,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,7 +7,7 @@ use tantivy as tv;
 ///
 /// The schema is very strict. To build the schema the `SchemaBuilder` class is
 /// provided.
-#[pyclass(frozen, module = "tantivy")]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 #[derive(Deserialize, PartialEq, Serialize)]
 pub(crate) struct Schema {
     pub(crate) inner: tv::schema::Schema,

--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -23,7 +23,7 @@ use tantivy::schema::{
 ///     >>> body = builder.add_text_field("body")
 ///
 ///     >>> schema = builder.build()
-#[pyclass]
+#[pyclass(module = "tantivy.tantivy")]
 #[derive(Clone)]
 pub(crate) struct SchemaBuilder {
     pub(crate) builder: Arc<RwLock<Option<schema::SchemaBuilder>>>,

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -9,7 +9,7 @@ use tantivy::collector::{Count, MultiCollector, TopDocs};
 /// Tantivy's Searcher class
 ///
 /// A Searcher is used to search the index given a prepared Query.
-#[pyclass]
+#[pyclass(module = "tantivy.tantivy")]
 pub(crate) struct Searcher {
     pub(crate) inner: tv::Searcher,
 }
@@ -40,7 +40,7 @@ impl ToPyObject for Fruit {
     }
 }
 
-#[pyclass(frozen, module = "tantivy")]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 #[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
 /// Enum representing the direction in which something should be sorted.
 pub(crate) enum Order {
@@ -60,7 +60,7 @@ impl From<Order> for tv::Order {
     }
 }
 
-#[pyclass(frozen, module = "tantivy")]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 #[derive(Clone, Default, Deserialize, PartialEq, Serialize)]
 /// Object holding a results successful search.
 pub(crate) struct SearchResult {
@@ -269,7 +269,7 @@ impl Searcher {
 /// It consists in an id identifying its segment, and its segment-local DocId.
 /// The id used for the segment is actually an ordinal in the list of segment
 /// hold by a Searcher.
-#[pyclass(frozen, module = "tantivy")]
+#[pyclass(frozen, module = "tantivy.tantivy")]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub(crate) struct DocAddress {
     pub(crate) segment_ord: tv::SegmentOrdinal,

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -6,12 +6,12 @@ use tantivy as tv;
 ///
 /// The schema is very strict. To build the schema the `SchemaBuilder` class is
 /// provided.
-#[pyclass]
+#[pyclass(module = "tantivy.tantivy")]
 pub(crate) struct Snippet {
     pub(crate) inner: tv::Snippet,
 }
 
-#[pyclass]
+#[pyclass(module = "tantivy.tantivy")]
 pub(crate) struct Range {
     #[pyo3(get)]
     start: usize,
@@ -38,7 +38,7 @@ impl Snippet {
     }
 }
 
-#[pyclass]
+#[pyclass(module = "tantivy.tantivy")]
 pub(crate) struct SnippetGenerator {
     pub(crate) field_name: String,
     pub(crate) inner: tv::SnippetGenerator,


### PR DESCRIPTION
As identified by @pawamoy, the canonical import path is `tantivy.tantivy`. Our examples work with a single `import tantivy` only because the toplevel module re-imports everything. The correct hierarchy is required for documentation tools to real docstrings correctly.