### PR TITLE
doc: Add mktestdocs, and tutorial for snippets. Fixes #219

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs==1.4.3
+mktestdocs==0.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 maturin
 pytest>=4.0
+mktestdocs==0.2.1

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import pytest
+
+from mktestdocs import check_md_file
+
+def test_hello():
+    assert True
+
+
+@pytest.mark.parametrize("filepath", Path("docs").glob("**/*.md"), ids=str)
+def test_docs(filepath):
+    check_md_file(filepath, memory=True)


### PR DESCRIPTION
Quite a nice feature. The `mktestdocs` package automates running all the code in the mkdocs documentation. This means we can keep our docs having actually working code. I found a couple bugs while setting this up.

I've also added a short tutorial for snippets, using the existing test as an example.