### PR TITLE
expose regex query

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,4 @@
-use crate::{make_term, Schema};
+use crate::{get_field, make_term, to_pyerr, Schema};
 use pyo3::{exceptions, prelude::*, types::PyAny, types::PyString};
 use tantivy as tv;
 
@@ -90,5 +90,24 @@ impl Query {
         Ok(Query {
             inner: Box::new(inner),
         })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (schema, field_name, regex_pattern))]
+    pub(crate) fn regex_query(
+        schema: &Schema,
+        field_name: &str,
+        regex_pattern: &str,
+    ) -> PyResult<Query> {
+        let field = get_field(&schema.inner, field_name)?;
+
+        let inner_result =
+            tv::query::RegexQuery::from_pattern(regex_pattern, field);
+        match inner_result {
+            Ok(inner) => Ok(Query {
+                inner: Box::new(inner),
+            }),
+            Err(e) => Err(to_pyerr(e)),
+        }
     }
 }

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -200,7 +200,10 @@ class Query:
     @staticmethod
     def fuzzy_term_query(schema: Schema, field_name: str, text: str, distance: int = 1, transposition_cost_one: bool = True, prefix = False) -> Query:
         pass
-
+    
+    @staticmethod
+    def regex_query(schema: Schema, field_name: str, regex_pattern: str) -> Query:
+        pass
 
 class Order(Enum):
     Asc = 1

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -819,4 +819,30 @@ class TestQuery(object):
             titles.update(index.searcher().doc(doc_address)["title"])
         assert titles == {"Frankenstein", "The Modern Prometheus"}
 
+    def test_regex_query(self, ram_index):
+        index = ram_index
 
+        query = Query.regex_query(index.schema, "body", "fish")
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+        _, doc_address = result.hits[0]
+        searched_doc = index.searcher().doc(doc_address)
+        assert searched_doc["title"] == ["The Old Man and the Sea"]
+        
+        query = Query.regex_query(index.schema, "title", "(?:man|men)")
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 2
+        _, doc_address = result.hits[0]
+        searched_doc = index.searcher().doc(doc_address)
+        assert searched_doc["title"] == ["The Old Man and the Sea"]
+        _, doc_address = result.hits[1]
+        searched_doc = index.searcher().doc(doc_address)
+        assert searched_doc["title"] == ["Of Mice and Men"]
+
+        # unknown field in the schema
+        with pytest.raises(ValueError, match="Field `unknown_field` is not defined in the schema."):
+            Query.regex_query(index.schema, "unknown_field", "fish")
+        
+        # invalid regex pattern
+        with pytest.raises(ValueError, match=r"An invalid argument was passed: 'fish\('"):
+            Query.regex_query(index.schema, "body", "fish(")


### PR DESCRIPTION
Exposed the regex query function based on the rust version's crate documentation.

Expected usage:

```python
@staticmethod
def regex_query(schema: Schema, field_name: str, regex_pattern: str) -> Query:
    ...

query = Query.regex_query(index.schema, "body", "fish")
```

Raises error if the field name doesn't found, or the regex pattern is not valid.

Currently this query must be created outside from the query parser