### PR TITLE
Expose the method of boolean query

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod snippet;
 use document::Document;
 use facet::Facet;
 use index::Index;
-use query::Query;
+use query::{Occur, Query};
 use schema::Schema;
 use schemabuilder::SchemaBuilder;
 use searcher::{DocAddress, Order, SearchResult, Searcher};
@@ -87,6 +87,7 @@ fn tantivy(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Query>()?;
     m.add_class::<Snippet>()?;
     m.add_class::<SnippetGenerator>()?;
+    m.add_class::<Occur>()?;
 
     m.add_wrapped(wrap_pymodule!(query_parser_error))?;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,11 +1,53 @@
 use crate::{make_term, Schema};
-use pyo3::{exceptions, prelude::*, types::PyAny, types::PyString};
+use pyo3::{exceptions, prelude::*, types::PyAny, types::PyString, types::PyTuple};
 use tantivy as tv;
+
+/// Custom Tuple struct to represent a pair of Occur and Query
+/// for the BooleanQuery
+struct OccurQueryPair(Occur, Query);
+
+impl <'source> FromPyObject<'source> for OccurQueryPair {
+    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+        let tuple = ob.downcast::<PyTuple>()?;
+        let occur = tuple.get_item(0)?.extract()?;
+        let query = tuple.get_item(1)?.extract()?;
+
+        Ok(OccurQueryPair(occur, query))
+    }
+}
+
+
+/// Tantivy's Occur
+#[pyclass(frozen, module = "tantivy.tantivy")]
+#[derive(Clone)]
+pub enum Occur {
+    Must,
+    Should,
+    MustNot,
+}
+
+impl From<Occur> for tv::query::Occur {
+    fn from(occur: Occur) -> tv::query::Occur {
+        match occur {
+            Occur::Must => tv::query::Occur::Must,
+            Occur::Should => tv::query::Occur::Should,
+            Occur::MustNot => tv::query::Occur::MustNot,
+        }
+    }
+}
 
 /// Tantivy's Query
 #[pyclass(frozen, module = "tantivy.tantivy")]
 pub(crate) struct Query {
     pub(crate) inner: Box<dyn tv::query::Query>,
+}
+
+impl Clone for Query {
+    fn clone(&self) -> Self {
+        Query {
+            inner: self.inner.box_clone(),
+        }
+    }
 }
 
 impl Query {
@@ -87,6 +129,23 @@ impl Query {
                 transposition_cost_one,
             )
         };
+        Ok(Query {
+            inner: Box::new(inner),
+        })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (subqueries))]
+    pub(crate) fn boolean_query(
+        subqueries: Vec<(Occur, Query)>
+    ) -> PyResult<Query> {
+        let dyn_subqueries = subqueries
+            .into_iter()
+            .map(|(occur, query)| (occur.into(), query.inner.box_clone()))
+            .collect::<Vec<_>>();
+        
+        let inner = tv::query::BooleanQuery::from(dyn_subqueries);
+
         Ok(Query {
             inner: Box::new(inner),
         })

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 
 class Schema:
@@ -187,6 +187,10 @@ class Document:
     def get_all(self, field_name: str) -> list[Any]:
         pass
 
+class Occur(Enum):
+    Must = 1
+    Should = 2
+    MustNot = 3
 
 class Query:
     @staticmethod
@@ -200,7 +204,10 @@ class Query:
     @staticmethod
     def fuzzy_term_query(schema: Schema, field_name: str, text: str, distance: int = 1, transposition_cost_one: bool = True, prefix = False) -> Query:
         pass
-
+    
+    @staticmethod
+    def boolean_query(subqueries: Sequence[tuple[Occur, Query]]) -> Query:
+        pass
 
 class Order(Enum):
     Asc = 1


### PR DESCRIPTION
Added the `Occur` enum, `Query.boolean_query` method and corresponding tests.

Expected usage:

```python
@staticmethod
def boolean_query(subqueries: Sequence[tuple[Occur, Query]]) -> Query:
    ...

Query.boolean_query([(Occur.Must, query1), (Occur.MustNot, query2), (Occur.Should, query3)])
```

<u>**Important Changes**</u>
- Added a wrapper struct `struct OccurQueryPair(Occur, Query)` which lives in the lifetime of the python object `subqueries` for parsing list of tuple of Occur and Query
- Added the `Clone` implementation of `Query` class for the `extract()` method to extract Query class from the PyTuple