### PR TITLE
Expose Tantivy's TermSetQuery

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -89,6 +89,26 @@ impl Query {
         })
     }
 
+    /// Construct a Tantivy's TermSetQuery
+    #[staticmethod]
+    #[pyo3(signature = (schema, field_name, field_values))]
+    pub(crate) fn term_set_query(
+        schema: &Schema,
+        field_name: &str,
+        field_values: Vec<&PyAny>,
+    ) -> PyResult<Query> {
+        let terms = field_values
+            .into_iter()
+            .map(|field_value| {
+                make_term(&schema.inner, field_name, &field_value)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let inner = tv::query::TermSetQuery::new(terms);
+        Ok(Query {
+            inner: Box::new(inner),
+        })
+    }
+
     /// Construct a Tantivy's AllQuery
     #[staticmethod]
     pub(crate) fn all_query() -> PyResult<Query> {

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -198,6 +198,10 @@ class Query:
         pass
 
     @staticmethod
+    def term_set_query(schema: Schema, field_name: str, field_values: Sequence[Any]) -> Query:
+        pass
+
+    @staticmethod
     def all_query() -> Query:
         pass
 


### PR DESCRIPTION
This PR adds the `Query.term_set_query` method and corresponding tests.

Expected usage:
```py
terms = ["old", "man"]
query = Query.term_set_query(index.schema, "title", terms)
result = index.searcher().search(query, 10)
```

The new `term_set_query` method has a signature similar to the existing `term_query`:
```py
@staticmethod
def term_query(schema: Schema, field_name: str, field_value: Any, index_option: str = "position") -> Query:
    pass

@staticmethod
def term_set_query(schema: Schema, field_name: str, field_values: Sequence[Any]) -> Query:
    pass
```


See also issue https://github.com/quickwit-oss/tantivy-py/issues/20.