### PR TITLE
Expose boost query

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -151,4 +151,13 @@ impl Query {
             inner: Box::new(inner),
         })
     }
+
+    #[staticmethod]
+    #[pyo3(signature = (query, boost))]
+    pub(crate) fn boost_query(query: Query, boost: f32) -> PyResult<Query> {
+        let inner = tv::query::BoostQuery::new(query.inner, boost);
+        Ok(Query {
+            inner: Box::new(inner),
+        })
+    }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,8 @@
 use crate::{make_term, Schema};
 use pyo3::{
-    exceptions, prelude::*, types::PyAny, types::PyString, types::PyTuple,
+    exceptions,
+    prelude::*,
+    types::{PyAny, PyString, PyTuple},
 };
 use tantivy as tv;
 
@@ -153,7 +155,7 @@ impl Query {
     }
 
     #[staticmethod]
-    #[pyo3(signature = (query, boost))]
+    #[pyo3(signature = (query, boost = 1.0))]
     pub(crate) fn boost_query(query: Query, boost: f32) -> PyResult<Query> {
         let inner = tv::query::BoostQuery::new(query.inner, boost);
         Ok(Query {

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -208,6 +208,10 @@ class Query:
     @staticmethod
     def boolean_query(subqueries: Sequence[tuple[Occur, Query]]) -> Query:
         pass
+    
+    @staticmethod
+    def boost_query(query: Query, boost: float) -> Query:
+        pass
 
 class Order(Enum):
     Asc = 1

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -210,7 +210,7 @@ class Query:
         pass
     
     @staticmethod
-    def boost_query(query: Query, boost: float) -> Query:
+    def boost_query(query: Query, boost: float = 1.0) -> Query:
         pass
 
 class Order(Enum):

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -930,6 +930,12 @@ class TestQuery(object):
             repr(boosted_query)
             == """Query(Boost(query=Boost(query=TermQuery(Term(field=0, type=Str, "sea")), boost=0.1), boost=0.1))"""
         )
+        result = index.searcher().search(boosted_query, 10)
+        for _score, _ in result.hits:
+            # the score should be very small, due to 
+            # the unknown score of BM25, we can only check for the relative difference
+            assert _score == pytest.approx(0.01, rel = 1)  
+
 
         boosted_query = Query.boost_query(
             query1, -0.1
@@ -945,7 +951,10 @@ class TestQuery(object):
         # Even with a negative boost, the query should still match the document
         assert len(result.hits) == 1
         titles = set()
-        for _, doc_address in result.hits:
+        for _score, doc_address in result.hits:
+
+            # the score should be negative
+            assert _score < 0
             titles.update(index.searcher().doc(doc_address)["title"])
         assert titles == {"The Old Man and the Sea"}
 


### PR DESCRIPTION
Added BoostQuery class with tests.

Expected usage:
```python
@staticmethod
def boost_query(query: Query, boost: float = 1.0) -> Query:
    pass

# If we specify a boost value
Query.boost_query(BooleanQuery(...), 2)

# Default boost value is 1
Query.boost_query(BooleanQuery(...))
```

Test suite (✅ for expected success case, ❌ for expected failure case)
- ✅ Normal Boost Query
- ✅ Boost Query nested with other Query types
- ✅ Decimal boost values
- ✅ Default boost value (1.0)
- ✅ Boost Query nested in another Boost Query, and the quadratic boost effect
- ✅ Negative boost value (**negative score**)
- ❌ Wrong Query type
- ❌ Wrong Boost Value type

