### PR TITLE
chore: update python versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12"]
+        allow-prereleases: false
         include:
           - os: ubuntu-latest
             python-version: "3.13"
             allow-prereleases: true
           - os: ubuntu-latest
             python-version: "3.11"
+            allow-prereleases: false
           - os: ubuntu-latest
             python-version: "3.10"
+            allow-prereleases: false
           - os: ubuntu-latest
             python-version: 3.8
+            allow-prereleases: false
     runs-on: "${{ matrix.os }}"
     steps:
       - name: Harden Runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: ["3.12"]
         include:
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13-dev"
           - os: ubuntu-latest
             python-version: "3.11"
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12"]
-        allow-prereleases: false
+        allow-prereleases: [false]
         include:
           - os: ubuntu-latest
             python-version: "3.13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d  # 5.1.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ matrix.allow-prereleases }}
 
       - uses: dtolnay/rust-toolchain@bb45937a053e097f8591208d8e74c90db1873d07
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
         python-version: ["3.12"]
         include:
           - os: ubuntu-latest
-            python-version: "3.13-dev"
+            python-version: "3.13"
+            allow-prereleases: true
           - os: ubuntu-latest
             python-version: "3.11"
           - os: ubuntu-latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session):
     session.install("-rrequirements-dev.txt")
     session.install("-e", ".", "--no-build-isolation")


### PR DESCRIPTION
Python 3.8 is no longer available on the "macos-latest" target.  This is the current list of supported Python versions: https://devguide.python.org/versions/