### PR TITLE
Expose const score query

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -226,4 +226,13 @@ impl Query {
             Err(e) => Err(to_pyerr(e)),
         }
     }
+
+    #[staticmethod]
+    #[pyo3(signature = (query, score))]
+    pub(crate) fn const_score_query(query: Query, score: f32) -> PyResult<Query> {
+        let inner = tv::query::ConstScoreQuery::new(query.inner, score);
+        Ok(Query {
+            inner: Box::new(inner),
+        })
+    }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -157,6 +157,7 @@ impl Query {
         })
     }
 
+    /// Construct a Tantivy's BooleanQuery
     #[staticmethod]
     #[pyo3(signature = (subqueries))]
     pub(crate) fn boolean_query(
@@ -199,6 +200,7 @@ impl Query {
         })
     }
 
+    /// Construct a Tantivy's BoostQuery
     #[staticmethod]
     #[pyo3(signature = (query, boost))]
     pub(crate) fn boost_query(query: Query, boost: f32) -> PyResult<Query> {
@@ -208,6 +210,7 @@ impl Query {
         })
     }
 
+    /// Construct a Tantivy's RegexQuery
     #[staticmethod]
     #[pyo3(signature = (schema, field_name, regex_pattern))]
     pub(crate) fn regex_query(
@@ -227,6 +230,7 @@ impl Query {
         }
     }
 
+    /// Construct a Tantivy's ConstScoreQuery
     #[staticmethod]
     #[pyo3(signature = (query, score))]
     pub(crate) fn const_score_query(query: Query, score: f32) -> PyResult<Query> {

--- a/src/query.rs
+++ b/src/query.rs
@@ -233,7 +233,10 @@ impl Query {
     /// Construct a Tantivy's ConstScoreQuery
     #[staticmethod]
     #[pyo3(signature = (query, score))]
-    pub(crate) fn const_score_query(query: Query, score: f32) -> PyResult<Query> {
+    pub(crate) fn const_score_query(
+        query: Query,
+        score: f32,
+    ) -> PyResult<Query> {
         let inner = tv::query::ConstScoreQuery::new(query.inner, score);
         Ok(Query {
             inner: Box::new(inner),

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -233,6 +233,10 @@ class Query:
     def regex_query(schema: Schema, field_name: str, regex_pattern: str) -> Query:
         pass
 
+    @staticmethod
+    def const_score_query(query: Query, score: float) -> Query:
+        pass
+    
 class Order(Enum):
     Asc = 1
     Desc = 2


### PR DESCRIPTION
Added ConstScoreQuery class with tests.

Expected usage:
```python
@staticmethod
def const_score_query(query: Query, score: float) -> Query:
    pass

Query.const_score_query(BooleanQuery(...), 0.5)
```

