### PR TITLE
Expose Tantivy's MoreLikeThisQuery

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -153,6 +153,7 @@ impl Searcher {
     ///
     /// Raises a ValueError if there was an error with the search.
     #[pyo3(signature = (query, limit = 10, count = true, order_by_field = None, offset = 0, order = Order::Desc))]
+    #[allow(clippy::too_many_arguments)]
     fn search(
         &self,
         py: Python,

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -233,6 +233,20 @@ class Query:
     def regex_query(schema: Schema, field_name: str, regex_pattern: str) -> Query:
         pass
 
+    @staticmethod
+    def more_like_this_query(
+        doc_address: DocAddress,
+        min_doc_frequency: Optional[int] = 5,
+        max_doc_frequency: Optional[int] = None,
+        min_term_frequency: Optional[int] = 2,
+        max_query_terms: Optional[int] = 25,
+        min_word_length: Optional[int] = None,
+        max_word_length: Optional[int] = None,
+        boost_factor: Optional[float] = 1.0,
+        stop_words: list[str] = []
+    ) -> Query:
+        pass
+
 class Order(Enum):
     Asc = 1
     Desc = 2

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -1057,3 +1057,40 @@ class TestQuery(object):
             ValueError, match=r"An invalid argument was passed: 'fish\('"
         ):
             Query.regex_query(index.schema, "body", "fish(")
+
+    def test_more_like_this_query(self, ram_index):
+        index = ram_index
+
+        # first, search the target doc
+        query = Query.term_query(index.schema, "title", "man")
+        result = index.searcher().search(query, 1)
+        _, doc_address = result.hits[0]
+        searched_doc = index.searcher().doc(doc_address)
+        assert searched_doc["title"] == ["The Old Man and the Sea"]
+
+        # construct the default MLT Query
+        mlt_query = Query.more_like_this_query(doc_address)
+        assert (
+            repr(mlt_query)
+            == "Query(MoreLikeThisQuery { mlt: MoreLikeThis { min_doc_frequency: Some(5), max_doc_frequency: None, min_term_frequency: Some(2), max_query_terms: Some(25), min_word_length: None, max_word_length: None, boost_factor: Some(1.0), stop_words: [] }, target: DocumentAdress(DocAddress { segment_ord: 0, doc_id: 0 }) })"
+        )
+        result = index.searcher().search(mlt_query, 10)
+        assert len(result.hits) == 0
+
+        # construct a fine-tuned MLT Query
+        mlt_query = Query.more_like_this_query(
+            doc_address,
+            min_doc_frequency=2,
+            max_doc_frequency=10,
+            min_term_frequency=1,
+            max_query_terms=10,
+            min_word_length=2,
+            max_word_length=20,
+            boost_factor=2.0,
+            stop_words=["fish"])
+        assert (
+            repr(mlt_query)
+            == "Query(MoreLikeThisQuery { mlt: MoreLikeThis { min_doc_frequency: Some(2), max_doc_frequency: Some(10), min_term_frequency: Some(1), max_query_terms: Some(10), min_word_length: Some(2), max_word_length: Some(20), boost_factor: Some(2.0), stop_words: [\"fish\"] }, target: DocumentAdress(DocAddress { segment_ord: 0, doc_id: 0 }) })"
+        )
+        result = index.searcher().search(mlt_query, 10)
+        assert len(result.hits) > 0


### PR DESCRIPTION
#20 

This adds `more_like_this_query()`  to `Query`  class to enable searching similar docs to a target document.
This also includes minor changes to fix/suppress clippy warnings.

### Limitations

In this PR, [`DocumentFields`](https://github.com/quickwit-oss/tantivy/blob/99a59ad37e833e1129f7e1abd25738a0adfae73a/src/query/more_like_this/query.rs#L36) type MLTQuery is not supported. I think it can be a future work.