### PR TITLE
Add __and__ and __or__ to Query

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -65,6 +65,26 @@ impl Query {
         Ok(format!("Query({:?})", self.get()))
     }
 
+    pub(crate) fn __and__(&self, other: Query) -> Query {
+        let inner = tv::query::BooleanQuery::from(vec![
+            (tv::query::Occur::Must, self.inner.box_clone()),
+            (tv::query::Occur::Must, other.inner.box_clone()),
+        ]);
+        Query {
+            inner: Box::new(inner),
+        }
+    }
+
+    pub(crate) fn __or__(&self, other: Query) -> Query {
+        let inner = tv::query::BooleanQuery::from(vec![
+            (tv::query::Occur::Should, self.inner.box_clone()),
+            (tv::query::Occur::Should, other.inner.box_clone()),
+        ]);
+        Query {
+            inner: Box::new(inner),
+        }
+    }
+
     /// Construct a Tantivy's TermQuery
     #[staticmethod]
     #[pyo3(signature = (schema, field_name, field_value, index_option = "position"))]

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -64,6 +64,32 @@ class TestClass(object):
 
         assert len(result.hits) == 1
 
+    def test_combine_queries(self, ram_index):
+        index = ram_index
+
+        query1 = ram_index.parse_query("title:men", ["title"])
+        query2 = ram_index.parse_query("body:summer", ["body"])
+
+        combined_and = query1 & query2
+
+        searcher = index.searcher()
+        result = searcher.search(combined_and, 10)
+
+        # This is an AND query, so it should return 0 results since summer isn't present
+        assert len(result.hits) == 0
+
+        combined_or = query1 | query2
+
+        result = searcher.search(combined_or, 10)
+
+        assert len(result.hits) == 1
+
+        double_combined = (query1 & query2) | query1
+
+        result = searcher.search(double_combined, 10)
+
+        assert len(result.hits) == 1
+
     def test_and_query_numeric_fields(self, ram_index_numeric_fields):
         index = ram_index_numeric_fields
         searcher = index.searcher()


### PR DESCRIPTION
Very new to Tantivy and Rust, so if I missed something apologies!

It would be excellent to combine queries using syntax like `&`, `|`.

I maintain a library, [Docprompt](https://github.com/Page-Leaf/Docprompt), that uses Tantivy internally, and having these operators available would make my usage easier, as well as other developers that are trying to compose queries declarativly using python syntax.

I understand that are a lot of query types in Tantivy. If there are other areas/directions that need to be implemented before we can expose the python API to developers, let me know and I'm happy to implement. Cheers!

PS:

I think a natural followup would be a python-space `QueryParser` that allows Django/SqlAlchemy like ORM usage for constructing queries. To cite the unit tests:

Old:

```
query = index.parse_query("title:men AND body:winter", ["title", "body"])
```

New:

```
query = index.create_query(title="men") & index.create_query(body="winter")
```

This PR would be the very beginnings of a python API in that direction!