### PR TITLE
Expose SnippetGenerator.set_max_num_chars() so changing the default is possible

### DIFF
--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -80,4 +80,8 @@ impl SnippetGenerator {
         let result = self.inner.snippet(&text);
         Snippet { inner: result }
     }
+
+    pub fn set_max_num_chars(&mut self, max_num_chars: usize) {
+        self.inner.set_max_num_chars(max_num_chars);
+    }
 }

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -433,3 +433,6 @@ class SnippetGenerator:
 
     def snippet_from_doc(self, doc: Document) -> Snippet:
         pass
+
+    def set_max_num_chars(self, max_num_chars: int) -> None:
+        pass


### PR DESCRIPTION
SnippetGenerator has a default max length of 150 characters, this exposes the function to
change the default. 