### PR TITLE
Disable rust-cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       UNSAFE_PYO3_SKIP_VERSION_CHECK: ${{ matrix.unsafe-pyo3-skip-version-check }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12"]
         allow-prereleases: [false]
         unsafe-pyo3-skip-version-check: [0]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,6 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # 2.7.3
+          #- uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # 2.7.3
       - run: python -m pip install nox
       - run: nox -s test-${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,5 +100,5 @@ jobs:
           toolchain: "stable"
 
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # 2.7.3
-      - run: python3 -m pip install nox
+      - run: python -m pip install nox
       - run: nox -s test-${{ matrix.python-version }}


### PR DESCRIPTION
The rust-cache action is disabled because of weird errors when trying to link Python on Windows.