### PR TITLE
chore: deprecate python 3.8 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.13"
             allow-prereleases: false
+            unsafe-pyo3-skip-version-check: 1
           - os: ubuntu-latest
             python-version: "3.12"
             allow-prereleases: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         run: cargo fmt --check
 
   Test:
-    continue-on-error: ${{ matrix.python-version == '3.13' }}
     env:
       UNSAFE_PYO3_SKIP_VERSION_CHECK: ${{ matrix.unsafe-pyo3-skip-version-check }}
     strategy:
@@ -54,8 +53,10 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.13"
-            allow-prereleases: true
-            unsafe-pyo3-skip-version-check: 1
+            allow-prereleases: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            allow-prereleases: false
           - os: ubuntu-latest
             python-version: "3.11"
             allow-prereleases: false
@@ -64,9 +65,6 @@ jobs:
             allow-prereleases: false
           - os: ubuntu-latest
             python-version: 3.9
-            allow-prereleases: false
-          - os: ubuntu-latest
-            python-version: 3.8
             allow-prereleases: false
     runs-on: "${{ matrix.os }}"
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
-          python-version: 3.8
+          python-version: 3.9
           architecture: x64
 
       - uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab
@@ -57,7 +57,7 @@ jobs:
           manylinux: auto
           target: ${{ matrix.platform }}
           command: build
-          args: --release --sdist -o dist -i 3.8 3.9 3.10 3.11 3.12 3.13
+          args: --release --sdist -o dist -i 3.9 3.10 3.11 3.12 3.13
 
       - name: Upload wheels
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # 4.4.3
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         target: [x64]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f
@@ -107,7 +107,7 @@ jobs:
       attestations: write  # persist the attestation
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         target: ['universal2', 'x86_64-apple-darwin']
     steps:
       - name: Harden Runner
@@ -162,10 +162,10 @@ jobs:
         with:
           toolchain: "stable"
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/ci/deploy_mac.sh
+++ b/ci/deploy_mac.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 maturin publish \
-    --interpreter python3.8 \
+    --interpreter python3.9 \
     --username __token__ \
     --password "$MATURIN_PASSWORD" \
     --no-sdist

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session):
     session.install("-rrequirements-dev.txt")
     session.install("-e", ".", "--no-build-isolation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tantivy"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Python 3.8 is now end of life so removing from supported versions https://devguide.python.org/versions/
Python 3.13 shouldnt be special cased anymore