### PR TITLE
Expose snippet fragments

### DIFF
--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -38,6 +38,10 @@ impl Snippet {
             .collect::<Vec<_>>();
         results
     }
+
+    pub fn fragment(&self) -> PyResult<String> {
+        Ok(self.inner.fragment().to_string())
+    }
 }
 
 #[pyclass(module = "tantivy.tantivy")]

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -427,6 +427,9 @@ class Snippet:
     def highlighted(self) -> list[Range]:
         pass
 
+    def fragment(self) -> str:
+        pass
+
 class SnippetGenerator:
     @staticmethod
     def create(

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -861,6 +861,8 @@ class TestSnippets(object):
             first = highlights[0]
             assert first.start == 20
             assert first.end == 23
+            snippet_fragment = snippet.fragment()
+            assert snippet_fragment == "The Old Man and the Sea"
             html_snippet = snippet.to_html()
             assert html_snippet == "The Old Man and the <b>Sea</b>"
 


### PR DESCRIPTION
Exposes the `fragment` string that snippets are rendered from, consistent with the Rust version: https://docs.rs/tantivy/latest/src/tantivy/snippet/mod.rs.html#167-169