### PR TITLE
Build and register custom text analyzers from Tantivy builtins

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -214,3 +214,117 @@ assert html_snippet == (
 ```
 
 
+## Create a Custom Tokenizer (Text Analyzer)
+
+Tantivy provides several built-in tokenizers and filters that
+can be chained together to create new tokenizers (or
+'text analyzers') that better fit your needs.
+
+Tantivy-py lets you access these components, assemble them,
+and register the result with an index.
+
+Let's walk through creating and registering a custom text analyzer
+to see how everything fits together.
+
+### Example
+
+First, let's create a text analyzer. As explained further down,
+a text analyzer is a pipeline consisting of one tokenizer and
+any number of token filters.
+
+```python
+from tantivy import (
+    TextAnalyzer,
+    TextAnalyzerBuilder,
+    Tokenizer,
+    Filter,
+    Index,
+    SchemaBuilder
+)
+
+my_analyzer: TextAnalyzer = (
+    TextAnalyzerBuilder(
+        # Create a `Tokenizer` instance.
+        # It instructs the builder about which type of tokenizer
+        # to create internally and with which arguments.
+        Tokenizer.regex(r"(?i)([a-z]+)")
+    )
+    .filter(
+        # Create a `Filter` instance.
+        # Like `Tokenizer`, this object provides instructions
+        # to the builder.
+        Filter.lowercase()
+    )
+    .filter(
+        # Define custom words.
+        Filter.custom_stopword(["www", "com"])
+    )
+    # Finally, build a TextAnalyzer
+    # chaining all tokenizer > [filter, ...] steps together.
+    .build()
+)
+```
+
+We can check that our new analyzer is working as expected
+by passing some text to its `.analyze()` method.
+
+```python
+>>> my_analyzer.analyze('www.this1website1might1exist.com')
+['this', 'website', 'might', 'exist']
+```
+
+The next step is to register our analyzer with an index. Let's
+assume we already have one.
+
+```python
+index.register_tokenizer("custom_analyzer", my_analyzer)
+```
+
+To link an analyzer to a field in the index, pass the
+analyzer name to the `tokenizer_name=` parameter of
+the `SchemaBuilder`'s `add_text_field()` method.
+
+Here is the schema that was used to construct our index:
+
+```python
+schema = (
+    tantivy.SchemaBuilder()
+    .add_text_field("content", tokenizer_name="custom_analyzer")
+    .build()
+)
+index = Index(schema)
+```
+
+Summary:
+
+1. Use `TextAnalyzerBuilder`, `Tokenizer`, and `Filter` to build a `TextAnalyzer`
+2. The analyzer's `.analyze()` method lets you use your analyzer as a tokenizer from Python.
+3. Refer to your analyzer's name when building the index schema.
+4. Use the same name when registering your analyzer on the index.
+
+
+### On terminology: Tokenizer vs. Text Analyzer
+
+Tantivy-py mimics Tantivy's interface as closely as possible.
+This includes minor terminological inconsistencies, one of
+which is how Tantivy distinguishes between 'tokenizers' and
+'text analyzers'.
+
+Quite simply, a 'tokenizer' segments text into tokens.
+A 'text analyzer' is a pipeline consisting of one tokenizer
+and zero or more token filters. The `TextAnalyzer` is the
+primary object of interest when talking about how to
+change Tantivy's tokenization behavior.
+
+Slightly confusingly, though, the `Index` and `SchemaBuilder`
+interfaces use 'tokenizer' to mean 'text analyzer'.
+
+This inconsistency can be observed in `SchemaBuilder.add_text_field`, e.g. --
+
+```
+SchemaBuilder.add_text_field(..., tokenizer_name=<analyzer name>)`
+```
+
+-- and in the name of the `Index.register_tokenizer(...)` method, which actually
+serves to register a *text analyzer*.
+

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -269,8 +269,8 @@ We can check that our new analyzer is working as expected
 by passing some text to its `.analyze()` method.
 
 ```python
->>> my_analyzer.analyze('www.this1website1might1exist.com')
-['this', 'website', 'might', 'exist']
+# Will print: ['this', 'website', 'might', 'exist']
+my_analyzer.analyze('www.this1website1might1exist.com')
 ```
 
 The next step is to register our analyzer with an index. Let's

--- a/src/index.rs
+++ b/src/index.rs
@@ -12,6 +12,7 @@ use crate::{
     schema::Schema,
     searcher::Searcher,
     to_pyerr,
+    tokenizer::TextAnalyzer as PyTextAnalyzer,
 };
 use tantivy as tv;
 use tantivy::{
@@ -452,6 +453,15 @@ impl Index {
         let errors = errors.into_iter().map(|err| err.into_py(py)).collect();
 
         Ok((Query { inner: query }, errors))
+    }
+
+    /// Register a custom text analyzer by name. (Confusingly,
+    /// this is one of the places where Tantivy uses 'tokenizer' to refer to a
+    /// TextAnalyzer instance.)
+    ///
+    // Implementation notes: Skipped indirection of TokenizerManager.
+    pub fn register_tokenizer(&self, name: &str, analyzer: PyTextAnalyzer) {
+        self.index.tokenizers().register(name, analyzer.analyzer);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod schema;
 mod schemabuilder;
 mod searcher;
 mod snippet;
+mod tokenizer;
 
 use document::{extract_value, extract_value_for_type, Document};
 use facet::Facet;
@@ -20,6 +21,7 @@ use schema::{FieldType, Schema};
 use schemabuilder::SchemaBuilder;
 use searcher::{DocAddress, Order, SearchResult, Searcher};
 use snippet::{Snippet, SnippetGenerator};
+use tokenizer::{Filter, TextAnalyzer, TextAnalyzerBuilder, Tokenizer};
 
 /// Python bindings for the search engine library Tantivy.
 ///
@@ -87,6 +89,10 @@ fn tantivy(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<SnippetGenerator>()?;
     m.add_class::<Occur>()?;
     m.add_class::<FieldType>()?;
+    m.add_class::<Tokenizer>()?;
+    m.add_class::<TextAnalyzerBuilder>()?;
+    m.add_class::<Filter>()?;
+    m.add_class::<TextAnalyzer>()?;
 
     m.add_wrapped(wrap_pymodule!(query_parser_error))?;
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,0 +1,438 @@
+use pyo3::{exceptions::PyValueError, prelude::*};
+use tantivy::tokenizer as tvt;
+
+/// All Tantivy's built-in tokenizers in one place.
+/// Each static method, e.g. Tokenizer.simple(),
+/// creates a wrapper around a Tantivy tokenizer.
+///
+/// ## Example:
+///
+/// ```python
+/// tokenizer = Tokenizer.regex(r"\w+")
+/// ```
+///
+/// ## Usage
+///
+/// In general, tokenizer objects' only reason
+/// for existing is to be passed to
+/// TextAnalyzerBuilder(tokenizer=<tokenizer>)
+///
+/// https://docs.rs/tantivy/latest/tantivy/tokenizer/index.html
+///
+// ## Implementation details:
+//
+// This is a complex enum. Each variant is a struct
+// that defines the arguments accepted by the
+// corresponding tokenizer's constructor.
+// The enum members, e.g. _Raw, are not instantiated
+// directly because our version of pyo3 (0.21.0)
+// does not have the #[pyo3(constructor = ...)],
+// attribute yet, making it more sensible to
+// define constructor signatures using a separate method.
+#[pyclass(module = "tantivy.tokenizer")]
+#[derive(Debug)]
+pub enum Tokenizer {
+    _Raw {},
+    _Simple {},
+    _Whitespace {},
+    _Regex {
+        pattern: String,
+    },
+    _Ngram {
+        min_gram: usize,
+        max_gram: usize,
+        prefix_only: bool,
+    },
+    _Facet {},
+}
+
+#[pymethods]
+impl Tokenizer {
+    /// SimpleTokenizer
+    #[staticmethod]
+    fn simple() -> PyResult<Tokenizer> {
+        Ok(Tokenizer::_Simple {})
+    }
+
+    /// WhitespaceTokenizer
+    #[staticmethod]
+    fn whitespace() -> PyResult<Tokenizer> {
+        Ok(Tokenizer::_Whitespace {})
+    }
+
+    /// Raw Tokenizer
+    #[staticmethod]
+    fn raw() -> PyResult<Tokenizer> {
+        Ok(Tokenizer::_Raw {})
+    }
+
+    /// FacetTokenizer
+    #[staticmethod]
+    fn facet() -> PyResult<Tokenizer> {
+        Ok(Tokenizer::_Facet {})
+    }
+
+    /// Regextokenizer
+    #[staticmethod]
+    fn regex(pattern: String) -> PyResult<Tokenizer> {
+        Ok(Tokenizer::_Regex { pattern })
+    }
+
+    /// NgramTokenizer
+    ///
+    /// Args:
+    /// - min_gram (int): Minimum character length of each ngram.
+    /// - max_gram (int): Maximum character length of each ngram.
+    /// - prefix_only (bool, optional): If true, ngrams must count from the start of the word.
+    #[pyo3(signature=(min_gram=2,max_gram=3,prefix_only=false))]
+    #[staticmethod]
+    fn ngram(
+        min_gram: usize,
+        max_gram: usize,
+        prefix_only: bool,
+    ) -> PyResult<Tokenizer> {
+        Ok(Tokenizer::_Ngram {
+            min_gram,
+            max_gram,
+            prefix_only,
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("tantivy.Tokenizer({:?})", &self)
+    }
+}
+
+/// All Tantivy's builtin TokenFilters.
+///
+/// ## Exmaple
+///
+/// ```python
+/// filter = Filter.alpha_num()
+/// ```
+///
+/// ## Usage
+///
+/// In general, filter objects exist to
+/// be passed to the filter() method
+/// of a TextAnalyzerBuilder instance.
+///
+/// https://docs.rs/tantivy/latest/tantivy/tokenizer/index.html
+///
+// ## Implementation details:
+//
+// This is a complex enum. Each variant is a struct
+// that defines the arguments accepted by the
+// corresponding tokenizer's constructor.
+// The enum members, e.g. _AlphaNum, are not instantiated
+// directly because our version of pyo3 (0.21.0)
+// does not have the #[pyo3(constructor = ...)],
+// attribute yet, making it more sensible to
+// define constructor signatures using a separate method.
+#[pyclass(module = "tantivy.tokenizer")]
+#[derive(Debug)]
+pub enum Filter {
+    _AlphaNumOnly {},
+    _AsciiFolding {},
+    _LowerCaser {},
+    _RemoveLong { length_limit: usize },
+    _Stemmer { language: String },
+    _StopWord { language: String },
+    _CustomStopWord { stopwords: Vec<String> },
+    _SplitCompound { constituent_words: Vec<String> },
+}
+
+#[pymethods]
+impl Filter {
+    /// AlphaNumOnlyFilter
+    #[staticmethod]
+    fn alphanum_only() -> PyResult<Filter> {
+        Ok(Filter::_AlphaNumOnly {})
+    }
+
+    /// AsciiFoldingFilter
+    #[staticmethod]
+    fn ascii_fold() -> PyResult<Filter> {
+        Ok(Filter::_AsciiFolding {})
+    }
+
+    #[staticmethod]
+    fn lowercase() -> PyResult<Filter> {
+        Ok(Filter::_LowerCaser {})
+    }
+
+    /// RemoveLongFilter
+    ///
+    /// Args:
+    /// - length_limit (int): max character length of token.
+    #[staticmethod]
+    fn remove_long(length_limit: usize) -> PyResult<Filter> {
+        Ok(Filter::_RemoveLong { length_limit })
+    }
+
+    /// Stemmer
+    #[staticmethod]
+    fn stemmer(language: String) -> PyResult<Filter> {
+        Ok(Filter::_Stemmer { language })
+    }
+
+    /// StopWordFilter (builtin stop word list)
+    ///
+    /// Args:
+    /// - language (string): Stop words list language.
+    ///   Valid values: {
+    ///     "arabic", "danish", "dutch", "english", "finnish", "french", "german", "greek",
+    ///     "hungarian", "italian", "norwegian", "portuguese", "romanian", "russian",
+    ///     "spanish", "swedish", "tamil", "turkish"
+    ///   }
+    // ## Implementation notes:
+    // An enum would make more sense for `language`, but I'm not sure if it's worth it.
+    #[staticmethod]
+    fn stopword(language: String) -> PyResult<Filter> {
+        Ok(Filter::_StopWord { language })
+    }
+
+    /// StopWordFilter (user-provided stop word list)
+    ///
+    /// This variant of Filter.stopword() lets you provide
+    /// your own custom list of stopwords.
+    ///
+    /// Args:
+    /// - stopwords (list(str)): a list of words to be removed.
+    #[staticmethod]
+    fn custom_stopword(stopwords: Vec<String>) -> PyResult<Filter> {
+        Ok(Filter::_CustomStopWord { stopwords })
+    }
+
+    /// SplitCompoundWords
+    ///
+    /// https://docs.rs/tantivy/latest/tantivy/tokenizer/struct.SplitCompoundWords.html
+    ///
+    /// Args:
+    /// - constituent_words (list(string)): words that make up compound word (must be in order).
+    ///
+    /// Example:
+    ///
+    /// ```python
+    /// # useless, contrived example:
+    /// compound_spliter = Filter.split_compounds(['butter', 'fly'])
+    /// # Will split 'butterfly' -> ['butter', 'fly'],
+    /// # but won't split 'buttering' or 'buttercupfly'
+    /// ```
+    #[staticmethod]
+    fn split_compound(constituent_words: Vec<String>) -> PyResult<Filter> {
+        Ok(Filter::_SplitCompound { constituent_words })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("tantivy.Filter(kind={:?})", &self)
+    }
+}
+
+fn parse_language(lang: &str) -> Result<tvt::Language, String> {
+    match lang.to_lowercase().as_str() {
+        "arabic" => Ok(tvt::Language::Arabic),
+        "danish" => Ok(tvt::Language::Danish),
+        "dutch" => Ok(tvt::Language::Dutch),
+        "english" => Ok(tvt::Language::English),
+        "finnish" => Ok(tvt::Language::Finnish),
+        "french" => Ok(tvt::Language::French),
+        "german" => Ok(tvt::Language::German),
+        "greek" => Ok(tvt::Language::Greek),
+        "hungarian" => Ok(tvt::Language::Hungarian),
+        "italian" => Ok(tvt::Language::Italian),
+        "norwegian" => Ok(tvt::Language::Norwegian),
+        "portuguese" => Ok(tvt::Language::Portuguese),
+        "romanian" => Ok(tvt::Language::Romanian),
+        "russian" => Ok(tvt::Language::Russian),
+        "spanish" => Ok(tvt::Language::Spanish),
+        "swedish" => Ok(tvt::Language::Swedish),
+        "tamil" => Ok(tvt::Language::Tamil),
+        "turkish" => Ok(tvt::Language::Turkish),
+        _ => Err(format!("Unsupported language: {}", lang)),
+    }
+}
+
+/// Tantivy's TextAnalyzer
+///
+/// Do not instantiate this class directly.
+/// Use the `TextAnalyzerBuilder` class instead.
+#[derive(Clone)]
+#[pyclass(module = "tantivy.tantivy")]
+pub(crate) struct TextAnalyzer {
+    pub(crate) analyzer: tvt::TextAnalyzer,
+}
+
+#[pymethods]
+impl TextAnalyzer {
+    /// Tokenize a string
+    /// Args:
+    /// - text (string): text to tokenize.
+    /// Returns:
+    /// - list(string): a list of tokens/words.
+    fn analyze(&mut self, text: &str) -> Vec<String> {
+        let mut token_stream = self.analyzer.token_stream(text);
+        let mut tokens = Vec::new();
+
+        while token_stream.advance() {
+            tokens.push(token_stream.token().text.clone());
+        }
+        tokens
+    }
+}
+
+/// Tantivy's TextAnalyzerBuilder
+///
+/// # Example
+///
+/// ```python
+/// my_analyzer: TextAnalyzer = (
+///     TextAnalyzerBuilder(Tokenizer.simple())
+///     .filter(Filter.lowercase())
+///     .filter(Filter.ngram())
+///     .build()
+/// )
+/// ```
+///
+/// https://docs.rs/tantivy/latest/tantivy/tokenizer/struct.TextAnalyzerBuilder.html
+#[pyclass]
+pub struct TextAnalyzerBuilder {
+    builder: Option<tvt::TextAnalyzerBuilder>,
+}
+
+#[pymethods]
+impl TextAnalyzerBuilder {
+    #[new]
+    fn new(tokenizer: &Tokenizer) -> PyResult<Self> {
+        let builder: tvt::TextAnalyzerBuilder = match tokenizer {
+            Tokenizer::_Raw {} => {
+                tvt::TextAnalyzer::builder(tvt::RawTokenizer::default())
+                    .dynamic()
+            }
+            Tokenizer::_Simple {} => {
+                tvt::TextAnalyzer::builder(tvt::SimpleTokenizer::default())
+                    .dynamic()
+            }
+            Tokenizer::_Whitespace {} => {
+                tvt::TextAnalyzer::builder(tvt::WhitespaceTokenizer::default())
+                    .dynamic()
+            }
+            Tokenizer::_Regex { pattern } => tvt::TextAnalyzer::builder(
+                tvt::RegexTokenizer::new(pattern).map_err(|e| {
+                    PyErr::new::<PyValueError, _>(format!(
+                        "Invalid regex pattern: {}",
+                        e
+                    ))
+                })?, // tvt::RegexTokenizer::new(pattern) .unwrap(),
+            )
+            .dynamic(),
+            Tokenizer::_Ngram {
+                min_gram,
+                max_gram,
+                prefix_only,
+            } => tvt::TextAnalyzer::builder(
+                tvt::NgramTokenizer::new(*min_gram, *max_gram, *prefix_only)
+                    .unwrap(),
+            )
+            .dynamic(),
+            Tokenizer::_Facet {} => {
+                tvt::TextAnalyzer::builder(tvt::FacetTokenizer::default())
+                    .dynamic()
+            }
+        };
+
+        Ok(TextAnalyzerBuilder {
+            builder: Some(builder.dynamic()),
+        })
+    }
+
+    /// Add filter to the builder.
+    ///
+    /// Args:
+    /// - filter (Filter): a Filter object.
+    /// Returns:
+    /// - TextAnalyzerBuilder: A new instance of the builder
+    ///
+    /// Note: The builder is _not_ mutated in-place.
+    fn filter(&mut self, filter: &Filter) -> PyResult<Self> {
+        if let Some(builder) = self.builder.take() {
+            let new_builder: tvt::TextAnalyzerBuilder = match filter {
+                Filter::_AlphaNumOnly {} => {
+                    builder.filter_dynamic(tvt::AlphaNumOnlyFilter {})
+                }
+                Filter::_AsciiFolding {} => {
+                    builder.filter_dynamic(tvt::AsciiFoldingFilter)
+                }
+                Filter::_LowerCaser {} => {
+                    builder.filter_dynamic(tvt::LowerCaser)
+                }
+                Filter::_RemoveLong { length_limit } => builder.filter_dynamic(
+                    tvt::RemoveLongFilter::limit(*length_limit),
+                ),
+                Filter::_Stemmer { language } => {
+                    match parse_language(language) {
+                        Ok(lang) => {
+                            builder.filter_dynamic(tvt::Stemmer::new(lang))
+                        }
+                        Err(e) => {
+                            return Err(PyErr::new::<
+                                pyo3::exceptions::PyValueError,
+                                _,
+                            >(e))
+                        }
+                    }
+                }
+                Filter::_StopWord { language } => {
+                    match parse_language(language) {
+                        Ok(lang) => builder.filter_dynamic(
+                            tvt::StopWordFilter::new(lang).unwrap(),
+                        ),
+                        Err(e) => {
+                            return Err(PyErr::new::<
+                                pyo3::exceptions::PyValueError,
+                                _,
+                            >(e))
+                        }
+                    }
+                }
+                Filter::_CustomStopWord { stopwords } => builder
+                    .filter_dynamic(tvt::StopWordFilter::remove(
+                        stopwords.clone(),
+                    )),
+                Filter::_SplitCompound { constituent_words } => builder
+                    .filter_dynamic(
+                        tvt::SplitCompoundWords::from_dictionary(
+                            constituent_words,
+                        )
+                        .unwrap(),
+                    ),
+            };
+            Ok(TextAnalyzerBuilder {
+                builder: Some(new_builder),
+            })
+        } else {
+            Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "Builder has already been consumed",
+            ))
+        }
+    }
+
+    /// Build final TextAnalyzer object.
+    ///
+    /// Returns:
+    /// - TextAnalyzer with tokenizer and filters baked in.
+    ///
+    /// Tip: TextAnalyzer's `analyze(text) -> tokens` method lets you
+    /// easily check if your analyzer is working as expected.
+    fn build(&mut self) -> PyResult<TextAnalyzer> {
+        if let Some(builder) = self.builder.take() {
+            Ok(TextAnalyzer {
+                analyzer: builder.build(),
+            })
+        } else {
+            Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "Builder has already been consumed",
+            ))
+        }
+    }
+}

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -2,8 +2,10 @@ import datetime
 from enum import Enum
 from typing import Any, Optional, Sequence, TypeVar, Union
 
+
 class Schema:
     pass
+
 
 class SchemaBuilder:
     @staticmethod
@@ -101,6 +103,7 @@ class SchemaBuilder:
     def build(self) -> Schema:
         pass
 
+
 class Facet:
     @staticmethod
     def from_encoded(encoded_bytes: bytes) -> Facet:
@@ -126,6 +129,7 @@ class Facet:
 
     def to_path_str(self) -> str:
         pass
+
 
 class Document:
     def __new__(cls, **kwargs) -> Document:
@@ -185,10 +189,12 @@ class Document:
     def get_all(self, field_name: str) -> list[Any]:
         pass
 
+
 class Occur(Enum):
     Must = 1
     Should = 2
     MustNot = 3
+
 
 class FieldType(Enum):
     Text = 1
@@ -201,8 +207,12 @@ class FieldType(Enum):
     Bytes = 8
     Json = 9
     IpAddr = 10
-    
-_RangeType = TypeVar("_RangeType", bound=int | float | datetime.datetime | bool | str | bytes)
+
+
+_RangeType = TypeVar(
+    "_RangeType", bound=int | float | datetime.datetime | bool | str | bytes
+)
+
 
 class Query:
     @staticmethod
@@ -215,7 +225,9 @@ class Query:
         pass
 
     @staticmethod
-    def term_set_query(schema: Schema, field_name: str, field_values: Sequence[Any]) -> Query:
+    def term_set_query(
+        schema: Schema, field_name: str, field_values: Sequence[Any]
+    ) -> Query:
         pass
 
     @staticmethod
@@ -224,32 +236,37 @@ class Query:
 
     @staticmethod
     def fuzzy_term_query(
-            schema: Schema,
-            field_name: str,
-            text: str,
-            distance: int = 1,
-            transposition_cost_one: bool = True,
-            prefix=False,
+        schema: Schema,
+        field_name: str,
+        text: str,
+        distance: int = 1,
+        transposition_cost_one: bool = True,
+        prefix=False,
     ) -> Query:
         pass
 
     @staticmethod
-    def phrase_query(schema: Schema, field_name: str, words: list[Union[str, tuple[int, str]]], slop: int = 0) -> Query:
+    def phrase_query(
+        schema: Schema,
+        field_name: str,
+        words: list[Union[str, tuple[int, str]]],
+        slop: int = 0,
+    ) -> Query:
         pass
-
 
     @staticmethod
     def boolean_query(subqueries: Sequence[tuple[Occur, Query]]) -> Query:
         pass
 
     @staticmethod
-    def disjunction_max_query(subqueries: Sequence[Query], tie_breaker: Optional[float] = None) -> Query:
+    def disjunction_max_query(
+        subqueries: Sequence[Query], tie_breaker: Optional[float] = None
+    ) -> Query:
         pass
-    
+
     @staticmethod
     def boost_query(query: Query, boost: float) -> Query:
         pass
-
 
     @staticmethod
     def regex_query(schema: Schema, field_name: str, regex_pattern: str) -> Query:
@@ -265,14 +282,14 @@ class Query:
         min_word_length: Optional[int] = None,
         max_word_length: Optional[int] = None,
         boost_factor: Optional[float] = 1.0,
-        stop_words: list[str] = []
+        stop_words: list[str] = [],
     ) -> Query:
         pass
 
     @staticmethod
     def const_score_query(query: Query, score: float) -> Query:
         pass
-       
+
     @staticmethod
     def range_query(
         schema: Schema,
@@ -284,11 +301,12 @@ class Query:
         include_upper: bool = True,
     ) -> Query:
         pass
- 
+
 
 class Order(Enum):
     Asc = 1
     Desc = 2
+
 
 class DocAddress:
     def __new__(cls, segment_ord: int, doc: int) -> DocAddress:
@@ -302,10 +320,12 @@ class DocAddress:
     def doc(self) -> int:
         pass
 
+
 class SearchResult:
     @property
     def hits(self) -> list[tuple[Any, DocAddress]]:
         pass
+
 
 class Searcher:
     def search(
@@ -340,6 +360,7 @@ class Searcher:
     def doc_freq(self, field_name: str, field_value: Any) -> int:
         pass
 
+
 class IndexWriter:
     def add_document(self, doc: Document) -> int:
         pass
@@ -368,6 +389,7 @@ class IndexWriter:
 
     def wait_merging_threads(self) -> None:
         pass
+
 
 class Index:
     def __new__(
@@ -411,6 +433,11 @@ class Index:
     ) -> Query:
         pass
 
+    def register_tokenizer(
+        self, name: str, text_analyzer: TextAnalyzer
+    ) -> None: ...
+
+
 class Range:
     @property
     def start(self) -> int:
@@ -419,6 +446,7 @@ class Range:
     @property
     def end(self) -> int:
         pass
+
 
 class Snippet:
     def to_html(self) -> str:
@@ -443,5 +471,86 @@ class SnippetGenerator:
     def set_max_num_chars(self, max_num_chars: int) -> None:
         pass
 
-__version__: str
 
+class Tokenizer:
+    @staticmethod
+    def raw() -> Tokenizer:
+        pass
+
+    @staticmethod
+    def simple() -> Tokenizer:
+        pass
+
+    @staticmethod
+    def whitespace() -> Tokenizer:
+        pass
+
+    @staticmethod
+    def regex(pattern: str) -> Tokenizer:
+        pass
+
+    @staticmethod
+    def ngram(
+        min_gram: int = 2, max_gram: int = 3, prefix_only: bool = False
+    ) -> Tokenizer:
+        pass
+
+    @staticmethod
+    def facet() -> Tokenizer:
+        pass
+
+
+class Filter:
+
+    @staticmethod
+    def alphanum_only() -> Filter:
+        pass
+
+    @staticmethod
+    def ascii_fold() -> Filter:
+        pass
+
+    @staticmethod
+    def lowercase() -> Filter:
+        pass
+
+    @staticmethod
+    def remove_long(length_limit: int) -> Filter:
+        pass
+
+    @staticmethod
+    def stemmer(language: str) -> Filter:
+        pass
+
+    @staticmethod
+    def stopword(language: str) -> Filter:
+        pass
+
+    @staticmethod
+    def custom_stopword(stopwords: list[str]) -> Filter:
+        pass
+
+    @staticmethod
+    def split_compound(constituent_words: list[str]) -> Filter:
+        pass
+    
+
+class TextAnalyzer:
+
+    def analyze(self, text: str) -> list[str]:
+        pass
+
+
+class TextAnalyzerBuilder:
+
+    def __init__(self, tokenizer: Tokenizer):
+        pass
+
+    def filter(self, filter: Filter) -> TextAnalyzerBuilder:
+        pass
+
+    def build(self) -> TextAnalyzer:
+        pass
+
+
+__version__: str


### PR DESCRIPTION
This PR adds the ability to build new text analyzers using Tantivy's builtin tokenizers and filters, as listed in the tokenizer module docs (https://docs.rs/tantivy/latest/tantivy/tokenizer/index.html). New analyzers are registered with an index by name. The registered name links analyzers to the tokenizer name specified by text fields in the index's schema.

Here is an example:

```python
custom_analyzer = (
    tantivy.TextAnalyzerBuilder(tokenizer=tantivy.Tokenizer.whitespace())
    .filter(tantivy.Filter.lowercase())
    .build()
)

doc_text = "#03 8903 HELLO"
assert ["#03", "8903", "hello"] == custom_analyzer.analyze(doc_text)

schema = (
    tantivy.SchemaBuilder()
    .add_text_field("content", tokenizer_name="custom_analyzer")
    .build()
)

index = tantivy.Index(schema)
index.register_tokenizer("custom_analyzer", custom_analyzer)
```

Building a text analyzer happens through an interface that (more or less) follows Tantivy's design. I had to deviate from it in some places, usually because of some mismatch between Rust's way of doing things and what PyO3 permits.

Differences:

- `Tokenizer.simple()`, `Tokenizer.raw()`, etc... instead of Tantivy's `SimpleTokenizer`, `RawTokenizer`, etc.
  - Why: PyO3 does not permit traits in a pyclass's constructor. It would also mean having to define a Tokenizer base class in Python. I tried all sorts of indirection, but couldn't figure something out. In the end, an enum just seemed the simplest way to proceed.
- Likewise, `Filter.lowercase()` instead of Tantivy's `LowerCaser`. Why: same reason as previous point.
- `index.register_tokenizer()` instead of Tantivy's `index.tokenizers().register()`. The extra indirection didn't seem worth it to me.
- Just as tantivy-py instantiates `SchemaBuilder` directly instead of as `Schema.builder()` (the Tantivy way), my design instantiates `TextAnalyzerBuilder`directly, instead of as `TextAnalyzer.builder()`

Extras:

- Besides being able to create and register text analyzers, you can also _use_ the analyzer from Python to tokenize text. This means it's easier to manually build queries without having to reimplement the tokenization process in python.

State of this PR:

- Tests pass. Granted, I haven't written tests for every combination of tokenizer and filter, but so far I'm satisfied that it works. I'm happy to extend the set of tests though.
- I've added a tutorial section to the docs.
- I've updated the .pyi and added doc comments to the rust code.

Next steps:

- Disclaimer: I'm new to Rust. I got some help from Claude and Deepseek but neither is amazing at Rust. My changes haven't broken any tests, but still... I think you're going to want to review this contribution with a critical eye.

Random:

- While working on this, there was a PyO3 feature available in new releases that I wanted to use: enum constructor signatures. Upgrading PyO3 unleashed a bunch of compilation errors, so it seems for now we're stuck on the currently pinned version.