### PR TITLE
Add delete-by-query and deprecate delete_documents. fix #432 and #297

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -145,7 +145,7 @@ impl IndexWriter {
     }
 
     #[deprecated(
-        note = "This method is deprecated and will be removed in the future. Use either delete_documents_by_tokenized_term, or delete_documents_by_query."
+        note = "This method is deprecated and will be removed in the future. Use either delete_documents_by_term, or delete_documents_by_query."
     )]
     fn delete_documents(
         &mut self,

--- a/src/index.rs
+++ b/src/index.rs
@@ -150,7 +150,7 @@ impl IndexWriter {
         field_name: &str,
         field_value: &Bound<PyAny>,
     ) -> PyResult<u64> {
-        self.delete_documents_by_tokenized_term(field_name, field_value)
+        self.delete_documents_by_term(field_name, field_value)
     }
 
     /// Delete all documents containing a given term.

--- a/src/index.rs
+++ b/src/index.rs
@@ -144,7 +144,9 @@ impl IndexWriter {
         Ok(self.inner()?.commit_opstamp())
     }
 
-    #[deprecated(note = "This method is deprecated and will be removed in the future. Use either delete_documents_by_tokenized_term, or delete_documents_by_query.")]
+    #[deprecated(
+        note = "This method is deprecated and will be removed in the future. Use either delete_documents_by_tokenized_term, or delete_documents_by_query."
+    )]
     fn delete_documents(
         &mut self,
         field_name: &str,
@@ -174,7 +176,7 @@ impl IndexWriter {
     ///
     /// If the field_name is not on the schema raises ValueError exception.
     /// If the field_value is not supported raises Exception.
-    fn delete_documents_by_tokenized_term(
+    fn delete_documents_by_term(
         &mut self,
         field_name: &str,
         field_value: &Bound<PyAny>,
@@ -249,7 +251,9 @@ impl IndexWriter {
     /// If the query is not valid raises ValueError exception.
     /// If the query is not supported raises Exception.
     fn delete_documents_by_query(&mut self, query: &Query) -> PyResult<u64> {
-        self.inner()?.delete_query(query.inner.box_clone()).map_err(to_pyerr)
+        self.inner()?
+            .delete_query(query.inner.box_clone())
+            .map_err(to_pyerr)
     }
 
     /// If there are some merging threads, blocks until they all finish

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -388,6 +388,12 @@ class IndexWriter:
     def delete_documents(self, field_name: str, field_value: Any) -> int:
         pass
 
+    def delete_documents_by_tokenized_term(self, field_name: str, field_value: Any) -> int:
+        pass
+
+    def delete_documents_by_query(self, query: Query) -> int:
+        pass
+
     def wait_merging_threads(self) -> None:
         pass
 

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -388,7 +388,7 @@ class IndexWriter:
     def delete_documents(self, field_name: str, field_value: Any) -> int:
         pass
 
-    def delete_documents_by_tokenized_term(self, field_name: str, field_value: Any) -> int:
+    def delete_documents_by_term(self, field_name: str, field_value: Any) -> int:
         pass
 
     def delete_documents_by_query(self, query: Query) -> int:

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -1561,3 +1561,33 @@ class TestTokenizers:
         )
         doc_text = "that is, like, such a weird way to, like, test"
         assert ["weird", "way", "test"] == analyzer.analyze(doc_text)
+
+    def test_delete_documents_by_query(self):
+        schema_builder = SchemaBuilder()
+        schema_builder.add_text_field("id", fast=True)
+        schema = schema_builder.build()
+        index = Index(schema)
+        writer = index.writer()
+        id_str = "test-1"
+        source_doc = {
+            "id": id_str,
+        }
+        writer.add_json(json.dumps(source_doc))
+        writer.commit()
+        writer.wait_merging_threads()
+        index.reload()
+
+        query = index.parse_query(f"id:{id_str}")
+        result = index.searcher().search(query)
+        assert result.count == 1
+
+        writer = index.writer()
+        # writer.delete_documents("id", id_str)
+        writer.delete_documents_by_query(query)
+        writer.commit()
+        writer.wait_merging_threads()
+
+        index.reload()
+        result = index.searcher().search(query)
+        index.reload()
+        assert result.count == 0

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -565,12 +565,12 @@ class TestUpdateClass(object):
         writer = ram_index.writer()
 
         with pytest.raises(ValueError):
-            writer.delete_documents("fake_field", "frankenstein")
+            writer.delete_documents_by_term("fake_field", "frankenstein")
 
         with pytest.raises(ValueError):
-            writer.delete_documents("title", b"frankenstein")
+            writer.delete_documents_by_term("title", b"frankenstein")
 
-        writer.delete_documents("title", "frankenstein")
+        writer.delete_documents_by_term("title", "frankenstein")
         writer.commit()
         ram_index.reload()
 
@@ -1582,7 +1582,6 @@ class TestTokenizers:
         assert result.count == 1
 
         writer = index.writer()
-        # writer.delete_documents("id", id_str)
         writer.delete_documents_by_query(query)
         writer.commit()
         writer.wait_merging_threads()


### PR DESCRIPTION
Quick recap: we're trying to solve the very confusing problem of `delete_documents(<field>, <value>)` not applying query parsing rules like tokenization to `<value>`. This is a bit of a footgun currently so we need to improve the dev experience here.

Based on my earlier work and thinking in #435, I think this is the best way to go:

1. Add a new method `delete_documents_by_query()`, which exposes the `delete_query` method from tantivy
2. Add a new method name `delete_documents_by_term`, which does the same things as what `delete_documents` used to do.
3. Retain `delete_documents()`, but make it a wrapper that calls `delete_documents_by_term` and put a deprecation notice on the wrapper.  Then we can look at removing the wrapper in a future version.