### PR TITLE
document.rs: remove unused PyDateAccess and PyTimeAccess imports

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -5,10 +5,7 @@ use itertools::Itertools;
 use pyo3::{
     basic::CompareOp,
     prelude::*,
-    types::{
-        PyAny, PyBool, PyDateAccess, PyDateTime, PyDict, PyInt, PyList,
-        PyTimeAccess, PyTuple,
-    },
+    types::{PyAny, PyBool, PyDateTime, PyDict, PyInt, PyList, PyTuple},
     IntoPyObjectExt, Python,
 };
 


### PR DESCRIPTION
This is needed for `abi3` builds (#80) which won't have `PyDateAccess` and `PyTimeAccess` according to https://github.com/PyO3/pyo3/pull/4970.