### PR TITLE
Helper methods for building boolean queries

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -184,12 +184,99 @@ complex_query = Query.boolean_query(
 
 <!--TODO: Update the reference link to the query parser docs when available.-->
 
+## Combining Queries with the Boolean Helper Methods
+
+`Query.boolean_query(...)` shown above is the most general way to combine
+queries, but for the common AND, OR and AND-NOT combinations there are three
+convenience methods that read more naturally:
+
+- `q.and_must_match(*queries)` matches documents that match `q` and every
+  given query (AND)
+- `q.and_must_not_match(*queries)` matches documents that match `q` and none
+  of the given queries (AND NOT)
+- `q.or_should_match(*queries)` matches documents that match `q` or any of
+  the given queries (OR)
+
+Each method returns a new `Query`, leaving the originals untouched.
+
+```python
+from tantivy import Query
+
+query_old = Query.term_query(schema, "title", "old")
+query_man = Query.term_query(schema, "title", "man")
+query_whale = Query.term_query(schema, "title", "whale")
+
+# Match documents whose title contains both "old" AND "man"
+combined = query_old.and_must_match(query_man)
+(score, doc_address) = searcher.search(combined, 3).hits[0]
+assert searcher.doc(doc_address)["title"] == ["The Old Man and the Sea"]
+
+# Match documents whose title contains "old" but NOT "whale"
+combined = query_old.and_must_not_match(query_whale)
+assert len(searcher.search(combined, 3).hits) > 0
+
+# Match documents whose title contains "old" OR "whale"
+combined = query_old.or_should_match(query_whale)
+assert len(searcher.search(combined, 3).hits) > 0
+```
+
+The methods accept any number of queries, so a list of queries can be applied
+in a single call using argument unpacking:
+
+```python
+query_sea = Query.term_query(schema, "title", "sea")
+
+# Equivalent to query_old.and_must_match(query_man, query_sea)
+queries = [query_man, query_sea]
+combined = query_old.and_must_match(*queries)
+assert len(searcher.search(combined, 3).hits) > 0
+```
+
+The methods can also be chained:
+
+```python
+combined = (
+    query_old
+    .and_must_match(query_man)
+    .and_must_not_match(query_whale)
+    .or_should_match(query_sea)
+)
+assert len(searcher.search(combined, 3).hits) > 0
+```
+
+Note how the precedence works: each call in the chain applies to the whole
+query built so far, not just to the preceding step. So the
+`or_should_match(query_sea)` call above applies to the combination of the
+first three queries, and the chain matches documents satisfying
+"(old AND man AND NOT whale) OR sea". There is no AND-before-OR operator
+precedence as in the boolean expressions of most programming languages;
+grouping simply follows the order of the method calls, left to right. For any
+other grouping, build the groups as separate queries first and then combine
+them:
+
+```python
+# old AND (man OR sea)
+man_or_sea = query_man.or_should_match(query_sea)
+combined = query_old.and_must_match(man_or_sea)
+assert len(searcher.search(combined, 3).hits) > 0
+```
+
+Although you can think of each call as wrapping the query built so far in a
+new boolean query, the helpers avoid building one level of nesting per call
+where they can: when the query being extended is already a boolean query, the
+new clauses are appended to it directly, provided that doing so matches the
+same documents. This is the case for `and_must_match` and
+`and_must_not_match` chains generally, and for `or_should_match` when the
+query built so far is a pure OR. So a long chain of AND clauses produces a
+single flat boolean query rather than a deeply nested one. This is purely an
+internal optimization — the matched documents are the same either way.
+
 ## Debugging Queries with explain()
 
 When working with search queries, it's often useful to understand why a particular document matched a query and how its score was calculated. The `explain()` method provides detailed information about the scoring process.
 
 ```python
-# Continuing from the previous example, let's search and get the top result
+# Let's search with the complex_query built earlier and get the top result
 result = searcher.search(complex_query, 10)
 if result.hits:
     score, doc_address = result.hits[0]

--- a/src/query.rs
+++ b/src/query.rs
@@ -99,32 +99,71 @@ impl Query {
 
     /// This is an internal helper method for the BooleanQuery
     /// convenience methods (and_must_match, or_should_match, and_must_not_match).
+    /// It builds a new query in which each query in `others` is added as an
+    /// `other_occur` clause alongside `self`.
+    ///
+    /// When `self` is already a BooleanQuery, the new clauses are appended to
+    /// its clause list where doing so preserves matching semantics, so that
+    /// fluent chains stay flat instead of nesting one level per call:
+    ///
+    /// - Must/MustNot clauses can always be appended, provided the existing
+    ///   `minimum_number_should_match` is carried over. (Tantivy recomputes
+    ///   the minimum to 0 when a Must/MustNot clause is present, which would
+    ///   silently turn existing Should clauses from required-disjunction into
+    ///   optional scoring hints.)
+    /// - Should clauses can only be appended when the existing query is a
+    ///   plain disjunction: all clauses Should, with the default minimum of 1.
+    ///   In any other case, e.g. `a.and_must_match(b).or_should_match(c)`,
+    ///   appending would change which documents match.
+    ///
+    /// In all other cases `self` is nested as a single `self_occur` clause of
+    /// a new BooleanQuery.
     fn combine_with(
         &self,
-        other: Query,
+        others: Vec<Query>,
         self_occur: tv::query::Occur,
         other_occur: tv::query::Occur,
     ) -> Query {
+        use tv::query::Occur;
         type BooleanQuery = tv::query::BooleanQuery;
 
-        let inner: Box<dyn tv::query::Query> = if let Some(boolean_query) =
-            self.inner.downcast_ref::<BooleanQuery>()
-        {
-            let mut subqueries = boolean_query
-                .clauses()
-                .iter()
-                .map(|(occur, subquery)| (*occur, subquery.box_clone()))
-                .collect::<Vec<_>>();
-            subqueries.push((other_occur, other.inner.box_clone()));
-            Box::new(BooleanQuery::new(subqueries))
-        } else {
-            Box::new(BooleanQuery::new(vec![
-                (self_occur, self.inner.box_clone()),
-                (other_occur, other.inner.box_clone()),
-            ]))
-        };
+        if others.is_empty() {
+            return self.clone();
+        }
+        let new_clauses = others.into_iter().map(|query| (other_occur, query.inner));
 
-        Query { inner }
+        if let Some(boolean_query) = self.inner.downcast_ref::<BooleanQuery>() {
+            let minimum = boolean_query.get_minimum_number_should_match();
+            let appendable = match other_occur {
+                Occur::Must | Occur::MustNot => true,
+                Occur::Should => {
+                    minimum == 1
+                        && boolean_query
+                            .clauses()
+                            .iter()
+                            .all(|(occur, _)| *occur == Occur::Should)
+                }
+            };
+            if appendable {
+                let mut subqueries = boolean_query
+                    .clauses()
+                    .iter()
+                    .map(|(occur, subquery)| (*occur, subquery.box_clone()))
+                    .collect::<Vec<_>>();
+                subqueries.extend(new_clauses);
+                return Query {
+                    inner: Box::new(BooleanQuery::with_minimum_required_clauses(
+                        subqueries, minimum,
+                    )),
+                };
+            }
+        }
+
+        let mut subqueries = vec![(self_occur, self.inner.box_clone())];
+        subqueries.extend(new_clauses);
+        Query {
+            inner: Box::new(BooleanQuery::new(subqueries)),
+        }
     }
 }
 
@@ -406,40 +445,40 @@ impl Query {
         })
     }
 
-    /// Convenience method to combine two queries with AND (MUST) logic.
-    /// If the current query is already a BooleanQuery, it adds the new query
-    /// as an additional MUST clause. Otherwise, it creates a new BooleanQuery
-    /// with both the current and new queries as MUST clauses.
-    #[pyo3(signature = (query))]
-    pub(crate) fn and_must_match(&self, query: Query) -> PyResult<Query> {
+    /// Convenience method to combine queries with AND (MUST) logic.
+    /// Returns a query matching documents that match this query and every
+    /// given query. Accepts any number of queries, so a list can be passed
+    /// with argument unpacking: `query.and_must_match(*queries)`.
+    #[pyo3(signature = (*queries))]
+    pub(crate) fn and_must_match(&self, queries: Vec<Query>) -> PyResult<Query> {
         Ok(self.combine_with(
-            query,
+            queries,
             tv::query::Occur::Must,
             tv::query::Occur::Must,
         ))
     }
 
-    /// Convenience method to combine two queries with AND (MUST NOT) logic.
-    /// If the current query is already a BooleanQuery, it adds the new query
-    /// as an additional MUST NOT clause. Otherwise, it creates a new BooleanQuery
-    /// with the current query as a MUST clause and the new query as a MUST NOT clause.
-    #[pyo3(signature = (query))]
-    pub(crate) fn and_must_not_match(&self, query: Query) -> PyResult<Query> {
+    /// Convenience method to combine queries with AND NOT (MUST NOT) logic.
+    /// Returns a query matching documents that match this query and none of
+    /// the given queries. Accepts any number of queries, so a list can be
+    /// passed with argument unpacking: `query.and_must_not_match(*queries)`.
+    #[pyo3(signature = (*queries))]
+    pub(crate) fn and_must_not_match(&self, queries: Vec<Query>) -> PyResult<Query> {
         Ok(self.combine_with(
-            query,
+            queries,
             tv::query::Occur::Must,
             tv::query::Occur::MustNot,
         ))
     }
 
-    /// Convenience method to combine two queries with OR (SHOULD) logic.
-    /// If the current query is already a BooleanQuery, it adds the new query
-    /// as an additional SHOULD clause. Otherwise, it creates a new BooleanQuery
-    /// with both the current and new queries as SHOULD clauses.
-    #[pyo3(signature = (query))]
-    pub(crate) fn or_should_match(&self, query: Query) -> PyResult<Query> {
+    /// Convenience method to combine queries with OR (SHOULD) logic.
+    /// Returns a query matching documents that match this query or any of
+    /// the given queries. Accepts any number of queries, so a list can be
+    /// passed with argument unpacking: `query.or_should_match(*queries)`.
+    #[pyo3(signature = (*queries))]
+    pub(crate) fn or_should_match(&self, queries: Vec<Query>) -> PyResult<Query> {
         Ok(self.combine_with(
-            query,
+            queries,
             tv::query::Occur::Should,
             tv::query::Occur::Should,
         ))

--- a/src/query.rs
+++ b/src/query.rs
@@ -96,6 +96,36 @@ impl Query {
             })
             .collect()
     }
+
+    /// This is an internal helper method for the BooleanQuery
+    /// convenience methods (and_must_match, or_should_match, and_must_not_match).
+    fn combine_with(
+        &self,
+        other: Query,
+        self_occur: tv::query::Occur,
+        other_occur: tv::query::Occur,
+    ) -> Query {
+        type BooleanQuery = tv::query::BooleanQuery;
+
+        let inner: Box<dyn tv::query::Query> = if let Some(boolean_query) =
+            self.inner.downcast_ref::<BooleanQuery>()
+        {
+            let mut subqueries = boolean_query
+                .clauses()
+                .iter()
+                .map(|(occur, subquery)| (*occur, subquery.box_clone()))
+                .collect::<Vec<_>>();
+            subqueries.push((other_occur, other.inner.box_clone()));
+            Box::new(BooleanQuery::new(subqueries))
+        } else {
+            Box::new(BooleanQuery::new(vec![
+                (self_occur, self.inner.box_clone()),
+                (other_occur, other.inner.box_clone()),
+            ]))
+        };
+
+        Query { inner }
+    }
 }
 
 #[pymethods]
@@ -374,6 +404,45 @@ impl Query {
         Ok(Query {
             inner: Box::new(inner),
         })
+    }
+
+    /// Convenience method to combine two queries with AND (MUST) logic.
+    /// If the current query is already a BooleanQuery, it adds the new query
+    /// as an additional MUST clause. Otherwise, it creates a new BooleanQuery
+    /// with both the current and new queries as MUST clauses.
+    #[pyo3(signature = (query))]
+    pub(crate) fn and_must_match(&self, query: Query) -> PyResult<Query> {
+        Ok(self.combine_with(
+            query,
+            tv::query::Occur::Must,
+            tv::query::Occur::Must,
+        ))
+    }
+
+    /// Convenience method to combine two queries with AND (MUST NOT) logic.
+    /// If the current query is already a BooleanQuery, it adds the new query
+    /// as an additional MUST NOT clause. Otherwise, it creates a new BooleanQuery
+    /// with the current query as a MUST clause and the new query as a MUST NOT clause.
+    #[pyo3(signature = (query))]
+    pub(crate) fn and_must_not_match(&self, query: Query) -> PyResult<Query> {
+        Ok(self.combine_with(
+            query,
+            tv::query::Occur::Must,
+            tv::query::Occur::MustNot,
+        ))
+    }
+
+    /// Convenience method to combine two queries with OR (SHOULD) logic.
+    /// If the current query is already a BooleanQuery, it adds the new query
+    /// as an additional SHOULD clause. Otherwise, it creates a new BooleanQuery
+    /// with both the current and new queries as SHOULD clauses.
+    #[pyo3(signature = (query))]
+    pub(crate) fn or_should_match(&self, query: Query) -> PyResult<Query> {
+        Ok(self.combine_with(
+            query,
+            tv::query::Occur::Should,
+            tv::query::Occur::Should,
+        ))
     }
 
     /// Construct a Tantivy's DisjunctionMaxQuery

--- a/src/query.rs
+++ b/src/query.rs
@@ -130,7 +130,8 @@ impl Query {
         if others.is_empty() {
             return self.clone();
         }
-        let new_clauses = others.into_iter().map(|query| (other_occur, query.inner));
+        let new_clauses =
+            others.into_iter().map(|query| (other_occur, query.inner));
 
         if let Some(boolean_query) = self.inner.downcast_ref::<BooleanQuery>() {
             let minimum = boolean_query.get_minimum_number_should_match();
@@ -152,9 +153,11 @@ impl Query {
                     .collect::<Vec<_>>();
                 subqueries.extend(new_clauses);
                 return Query {
-                    inner: Box::new(BooleanQuery::with_minimum_required_clauses(
-                        subqueries, minimum,
-                    )),
+                    inner: Box::new(
+                        BooleanQuery::with_minimum_required_clauses(
+                            subqueries, minimum,
+                        ),
+                    ),
                 };
             }
         }
@@ -450,7 +453,10 @@ impl Query {
     /// given query. Accepts any number of queries, so a list can be passed
     /// with argument unpacking: `query.and_must_match(*queries)`.
     #[pyo3(signature = (*queries))]
-    pub(crate) fn and_must_match(&self, queries: Vec<Query>) -> PyResult<Query> {
+    pub(crate) fn and_must_match(
+        &self,
+        queries: Vec<Query>,
+    ) -> PyResult<Query> {
         Ok(self.combine_with(
             queries,
             tv::query::Occur::Must,
@@ -463,7 +469,10 @@ impl Query {
     /// the given queries. Accepts any number of queries, so a list can be
     /// passed with argument unpacking: `query.and_must_not_match(*queries)`.
     #[pyo3(signature = (*queries))]
-    pub(crate) fn and_must_not_match(&self, queries: Vec<Query>) -> PyResult<Query> {
+    pub(crate) fn and_must_not_match(
+        &self,
+        queries: Vec<Query>,
+    ) -> PyResult<Query> {
         Ok(self.combine_with(
             queries,
             tv::query::Occur::Must,
@@ -476,7 +485,10 @@ impl Query {
     /// the given queries. Accepts any number of queries, so a list can be
     /// passed with argument unpacking: `query.or_should_match(*queries)`.
     #[pyo3(signature = (*queries))]
-    pub(crate) fn or_should_match(&self, queries: Vec<Query>) -> PyResult<Query> {
+    pub(crate) fn or_should_match(
+        &self,
+        queries: Vec<Query>,
+    ) -> PyResult<Query> {
         Ok(self.combine_with(
             queries,
             tv::query::Occur::Should,

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -296,6 +296,15 @@ class Query:
     ) -> Query:
         pass
 
+    def and_must_match(self, query: Query) -> Query:
+        pass
+
+    def and_must_not_match(self, query: Query) -> Query:
+        pass
+
+    def or_should_match(self, query: Query) -> Query:
+        pass
+
     @staticmethod
     def disjunction_max_query(
         subqueries: Sequence[Query], tie_breaker: Optional[float] = None

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -296,13 +296,13 @@ class Query:
     ) -> Query:
         pass
 
-    def and_must_match(self, query: Query) -> Query:
+    def and_must_match(self, *queries: Query) -> Query:
         pass
 
-    def and_must_not_match(self, query: Query) -> Query:
+    def and_must_not_match(self, *queries: Query) -> Query:
         pass
 
-    def or_should_match(self, query: Query) -> Query:
+    def or_should_match(self, *queries: Query) -> Query:
         pass
 
     @staticmethod

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -1296,6 +1296,68 @@ class TestQuery(object):
                 ]
             )
 
+    def test_boolean_query_helpers(self, ram_index: tantivy.Index):
+        index = ram_index
+        searcher = index.searcher()
+
+        # Queries for testing
+        query_sea = Query.term_query(index.schema, "title", "sea")  # Matches "The Old Man and the Sea"
+        query_mice = Query.term_query(index.schema, "title", "mice")  # Matches "Of Mice and Men"
+        query_old = Query.term_query(index.schema, "title", "old")  # Matches "The Old Man and the Sea"
+        query_man = Query.term_query(index.schema, "title", "man")  # Matches "The Old Man and the Sea"
+
+        # Test and_must_match
+        # No document contains both "sea" and "mice" in the title
+        combined_must = query_sea.and_must_match(query_mice)
+        result = searcher.search(combined_must, 10)
+        assert len(result.hits) == 0
+
+        # "The Old Man and the Sea" contains both "old" and "man"
+        combined_must = query_old.and_must_match(query_man)
+        result = searcher.search(combined_must, 10)
+        assert len(result.hits) == 1
+        searched_doc = searcher.doc(result.hits[0][1])
+        assert searched_doc["title"] == ["The Old Man and the Sea"]
+
+        # "The Old Man and the Sea" contains both "old" and "man"
+        # (but with many chains)
+        combined_must = (
+            query_old
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+            .and_must_match(query_man)
+        )
+        result = searcher.search(combined_must, 10)
+        assert len(result.hits) == 1
+        searched_doc = searcher.doc(result.hits[0][1])
+        assert searched_doc["title"] == ["The Old Man and the Sea"]
+
+        # Test or_should_match
+        # Should match documents containing either "sea" or "mice"
+        combined_should = query_sea.or_should_match(query_mice)
+        result = searcher.search(combined_should, 10)
+        assert len(result.hits) == 2
+        titles = {searcher.doc(hit[1])["title"][0] for hit in result.hits}
+        assert "The Old Man and the Sea" in titles
+        assert "Of Mice and Men" in titles
+
+        # Test and_must_not_match
+        # All 3 docs contain "and" in the body. We exclude the one with "sea" in the title.
+        query_and_body = Query.term_query(index.schema, "body", "and")
+        combined_must_not = query_and_body.and_must_not_match(query_sea)
+        result = searcher.search(combined_must_not, 10)
+        assert len(result.hits) == 2
+        titles = {searcher.doc(hit[1])["title"][0] for hit in result.hits}
+        assert "The Old Man and the Sea" not in titles
+
     def test_disjunction_max_query(self, ram_index):
         index = ram_index
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -1358,6 +1358,66 @@ class TestQuery(object):
         titles = {searcher.doc(hit[1])["title"][0] for hit in result.hits}
         assert "The Old Man and the Sea" not in titles
 
+    def test_boolean_query_helpers_multiple_queries(self, ram_index: tantivy.Index):
+        index = ram_index
+        searcher = index.searcher()
+
+        query_sea = Query.term_query(index.schema, "title", "sea")
+        query_mice = Query.term_query(index.schema, "title", "mice")
+        query_old = Query.term_query(index.schema, "title", "old")
+        query_man = Query.term_query(index.schema, "title", "man")
+        query_frankenstein = Query.term_query(index.schema, "title", "frankenstein")
+        query_and_body = Query.term_query(index.schema, "body", "and")
+
+        # Multiple queries in a single call
+        combined_must = query_old.and_must_match(query_man, query_sea)
+        result = searcher.search(combined_must, 10)
+        assert len(result.hits) == 1
+        assert searcher.doc(result.hits[0][1])["title"] == ["The Old Man and the Sea"]
+
+        combined_should = query_old.or_should_match(query_mice, query_frankenstein)
+        result = searcher.search(combined_should, 10)
+        assert len(result.hits) == 3
+
+        # A list of queries can be passed with argument unpacking.
+        # All 3 docs contain "and" in the body; exclude "sea" and "mice" titles.
+        excluded = [query_sea, query_mice]
+        combined_must_not = query_and_body.and_must_not_match(*excluded)
+        result = searcher.search(combined_must_not, 10)
+        assert len(result.hits) == 1
+        assert "Frankenstein" in searcher.doc(result.hits[0][1])["title"]
+
+        # Calling with no queries returns an equivalent query
+        result = searcher.search(query_old.and_must_match(), 10)
+        assert len(result.hits) == 1
+
+    def test_boolean_query_helpers_mixed_chains(self, ram_index: tantivy.Index):
+        """Chains mixing AND and OR must group the left-hand side correctly."""
+        index = ram_index
+        searcher = index.searcher()
+
+        query_mice = Query.term_query(index.schema, "title", "mice")
+        query_old = Query.term_query(index.schema, "title", "old")
+        query_man = Query.term_query(index.schema, "title", "man")
+        query_frankenstein = Query.term_query(index.schema, "title", "frankenstein")
+
+        # (old OR mice) AND frankenstein: no document satisfies both sides,
+        # so this must match nothing. The OR group must remain required and
+        # not degrade into optional scoring clauses next to the MUST clause.
+        combined = query_old.or_should_match(query_mice).and_must_match(
+            query_frankenstein
+        )
+        result = searcher.search(combined, 10)
+        assert len(result.hits) == 0
+
+        # (old AND man) OR mice: the AND group must stay grouped, with the
+        # OR applying to the whole of it.
+        combined = query_old.and_must_match(query_man).or_should_match(query_mice)
+        result = searcher.search(combined, 10)
+        assert len(result.hits) == 2
+        titles = {searcher.doc(hit[1])["title"][0] for hit in result.hits}
+        assert titles == {"The Old Man and the Sea", "Of Mice and Men"}
+
     def test_disjunction_max_query(self, ram_index):
         index = ram_index
 


### PR DESCRIPTION
This adds `.and_must_match()`, `and_must_not_match()`, and `or_should_match()` methods which produce boolean queries that can be chained in a fluent interface. Some care is taken to keep the chain flatter by reusing a BooleanQuery layer (and simply append the subsequent clauses).

Here's a silly example from the tests:

```python
        index = ram_index
        searcher = index.searcher()

        # Queries for testing
        query_mice = Query.term_query(index.schema, "title", "mice")  # Matches "Of Mice and Men"
        query_old = Query.term_query(index.schema, "title", "old")  # Matches "The Old Man and the Sea"
        query_man = Query.term_query(index.schema, "title", "man")  # Matches "The Old Man and the Sea"

        # "The Old Man and the Sea" contains both "old" and "man"
        # (but with many chains)
        combined_must = (
            query_old
            .and_must_match(query_man)
            .and_must_not_match(query_mice)
        )
        result = searcher.search(combined_must, 10)
        assert len(result.hits) == 1
```