### PR TITLE
Add support for custom tokenizers of fast fields

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -601,6 +601,23 @@ impl Index {
             self.index.tokenizers().register(&name, analyzer.analyzer);
         });
     }
+
+    /// Register a custom text analyzer for fast fields by name. (Confusingly,
+    /// this is one of the places where Tantivy uses 'tokenizer' to refer to a
+    /// TextAnalyzer instance.)
+    ///
+    // Implementation notes: Skipped indirection of TokenizerManager.
+    pub fn register_fast_field_tokenizer(
+        &self,
+        py: Python,
+        name: &str,
+        analyzer: PyTextAnalyzer,
+    ) {
+        py.detach(move || {
+            self.index.fast_field_tokenizer().register(&name, analyzer.analyzer);
+        });
+    }
+
 }
 
 impl Index {

--- a/src/index.rs
+++ b/src/index.rs
@@ -614,10 +614,11 @@ impl Index {
         analyzer: PyTextAnalyzer,
     ) {
         py.detach(move || {
-            self.index.fast_field_tokenizer().register(&name, analyzer.analyzer);
+            self.index
+                .fast_field_tokenizer()
+                .register(&name, analyzer.analyzer);
         });
     }
-
 }
 
 impl Index {

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -479,6 +479,10 @@ class Index:
         self, name: str, text_analyzer: TextAnalyzer
     ) -> None: ...
 
+    def register_fast_field_tokenizer(
+        self, name: str, text_analyzer: TextAnalyzer
+    ) -> None: ...
+
 
 class Range:
     @property

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -1564,12 +1564,14 @@ class TestTokenizers:
 
         schema = (
             tantivy.SchemaBuilder()
-            .add_text_field("content", tokenizer_name="custom_analyzer")
+            .add_text_field("content", fast=True, tokenizer_name="custom_analyzer")
             .build()
         )
 
         index = tantivy.Index(schema)
         index.register_tokenizer("custom_analyzer", custom_analyzer)
+        index.register_fast_field_tokenizer("custom_analyzer", custom_analyzer)
+
 
         writer = index.writer()
         doc = Document(content=doc_text)


### PR DESCRIPTION
**Why is this feature needed?**
Without it - you can't mark a field as both `fast=True` and to have a custom tokenizer.

The function is minimal, and I've adapted the existing integration test to cover it