### PR TITLE
implement inverted index range query

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -371,7 +371,7 @@ impl Query {
     }
 
     #[staticmethod]
-    #[pyo3(signature = (schema, field_name, field_type, lower_bound, upper_bound, include_lower = true, include_upper = true))]
+    #[pyo3(signature = (schema, field_name, field_type, lower_bound, upper_bound, include_lower = true, include_upper = true, use_inverted_index = false))]
     pub(crate) fn range_query(
         schema: &Schema,
         field_name: &str,
@@ -380,6 +380,7 @@ impl Query {
         upper_bound: &Bound<PyAny>,
         include_lower: bool,
         include_upper: bool,
+        use_inverted_index: bool,
     ) -> PyResult<Query> {
         match field_type {
             FieldType::Text => {
@@ -449,11 +450,20 @@ impl Query {
             OpsBound::Excluded(upper_bound_term)
         };
 
-        let inner = tv::query::RangeQuery::new(lower_bound, upper_bound);
-
-        Ok(Query {
-            inner: Box::new(inner),
-        })
+        if use_inverted_index {
+            let inner = tv::query::InvertedIndexRangeQuery::new(
+                lower_bound,
+                upper_bound,
+            );
+            return Ok(Query {
+                inner: Box::new(inner),
+            });
+        } else {
+            let inner = tv::query::RangeQuery::new(lower_bound, upper_bound);
+            return Ok(Query {
+                inner: Box::new(inner),
+            });
+        }
     }
 
     /// Explain how this query matches a given document.

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -313,6 +313,7 @@ class Query:
         upper_bound: _RangeType,
         include_lower: bool = True,
         include_upper: bool = True,
+        use_inverted_index: bool = False,
     ) -> Query:
         pass
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -1433,6 +1433,19 @@ class TestQuery(object):
         result = index.searcher().search(query, 10)
         assert len(result.hits) == 0
 
+    def test_range_query_numerics_with_inverted_index(self, ram_index_numeric_fields):
+        index = ram_index_numeric_fields
+
+        # test integer field including both bounds
+        query = Query.range_query(index.schema, "id", FieldType.Integer, 1, 2, use_inverted_index=True)
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 2
+
+        # test integer field excluding the lower bound
+        query = Query.range_query(index.schema, "id", FieldType.Integer, 1, 2, use_inverted_index=True, include_lower=False)
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
     def test_range_query_dates(self, ram_index_with_date_field):
         index = ram_index_with_date_field
 


### PR DESCRIPTION
Expanded on range_query, added another boolean to stay in line with the current package python spirit