### PR TITLE
feat: Add query_grammar bindings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod facet;
 mod index;
 mod parser_error;
 mod query;
+mod query_grammar;
 mod schema;
 mod schemabuilder;
 mod searcher;
@@ -19,6 +20,7 @@ use explanation::Explanation;
 use facet::Facet;
 use index::{Index, IndexWriter};
 use query::{Occur, Query};
+use query_grammar::{parse_query, parse_query_lenient};
 use schema::{FieldType, Schema};
 use schemabuilder::SchemaBuilder;
 use searcher::{DocAddress, Order, SearchResult, Searcher};
@@ -97,6 +99,9 @@ fn tantivy(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<TextAnalyzerBuilder>()?;
     m.add_class::<Filter>()?;
     m.add_class::<TextAnalyzer>()?;
+
+    m.add_function(wrap_pyfunction!(parse_query, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_query_lenient, m)?)?;
 
     m.add_wrapped(wrap_pymodule!(query_parser_error))?;
 

--- a/src/query_grammar.rs
+++ b/src/query_grammar.rs
@@ -1,0 +1,68 @@
+use crate::to_pyerr;
+use pyo3::{exceptions, prelude::*};
+use pythonize::pythonize;
+use tantivy as tv;
+
+/// Parse a query string into an abstract syntax tree (AST).
+///
+/// This function parses a query string following Tantivy's query language
+/// syntax and returns a Python dictionary representing the parsed AST.
+/// Unlike `Index.parse_query()`, this function does not require a schema
+/// and returns the raw syntax tree structure.
+///
+/// Args:
+///     query (str): The query string to parse.
+///
+/// Returns:
+///     dict: A dictionary representing the parsed query AST.
+///
+/// Raises:
+///     ValueError: If the query has invalid syntax.
+///
+/// Example:
+///     >>> import tantivy
+///     >>> ast = tantivy.parse_query("title:hello AND body:world")
+///     >>> print(ast)
+#[pyfunction]
+pub fn parse_query(py: Python, query: &str) -> PyResult<Py<PyAny>> {
+    let ast = tv::query_grammar::parse_query(query).map_err(|e| {
+        exceptions::PyValueError::new_err(format!(
+            "Query parsing error: {:?}",
+            e
+        ))
+    })?;
+    let py_obj = pythonize(py, &ast).map_err(to_pyerr)?;
+    Ok(py_obj.unbind())
+}
+
+/// Parse a query string leniently, recovering from syntax errors.
+///
+/// This function attempts to parse a query string even if it contains
+/// syntax errors. It returns both the parsed AST and a list of errors
+/// encountered during parsing. Unlike `Index.parse_query_lenient()`,
+/// this function does not require a schema and returns the raw syntax
+/// tree structure.
+///
+/// Args:
+///     query (str): The query string to parse.
+///
+/// Returns:
+///     tuple[dict, list]: A tuple containing:
+///         - dict: A dictionary representing the parsed query AST
+///         - list: A list of error dictionaries describing syntax errors
+///
+/// Example:
+///     >>> import tantivy
+///     >>> ast, errors = tantivy.parse_query_lenient("title:hello AND invalid:")
+///     >>> print(f"AST: {ast}")
+///     >>> print(f"Errors: {errors}")
+#[pyfunction]
+pub fn parse_query_lenient(
+    py: Python,
+    query: &str,
+) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
+    let (ast, errors) = tv::query_grammar::parse_query_lenient(query);
+    let py_ast = pythonize(py, &ast).map_err(to_pyerr)?;
+    let py_errors = pythonize(py, &errors).map_err(to_pyerr)?;
+    Ok((py_ast.unbind(), py_errors.unbind()))
+}

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -620,5 +620,33 @@ class TextAnalyzerBuilder:
     def build(self) -> TextAnalyzer:
         pass
 
+def parse_query(query: str) -> dict[str, Any]:
+    """
+    Parse a query string into an abstract syntax tree (AST).
+
+    Args:
+        query: The query string to parse.
+
+    Returns:
+        A dictionary representing the parsed query AST.
+
+    Raises:
+        ValueError: If the query has invalid syntax.
+    """
+    pass
+
+def parse_query_lenient(query: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """
+    Parse a query string leniently, recovering from syntax errors.
+
+    Args:
+        query: The query string to parse.
+
+    Returns:
+        A tuple containing:
+            - A dictionary representing the parsed query AST
+            - A list of error dictionaries describing syntax errors
+    """
+    pass
 
 __version__: str


### PR DESCRIPTION
Add bindings for the [query-grammar](https://docs.rs/tantivy-query-grammar/0.25.0/tantivy_query_grammar/index.html) functions `parse_query` and `parse_query_lenient`