### PR TITLE
perf: eliminate JSON round-trip in aggregate() and cardinality()

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -4,6 +4,7 @@ use crate::{document::Document, query::Query, to_pyerr};
 use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 use pyo3::{basic::CompareOp, exceptions::PyValueError, prelude::*};
+use pythonize::{depythonize, pythonize};
 use serde::{Deserialize, Serialize};
 use tantivy as tv;
 use tantivy::aggregation::AggregationCollector;
@@ -170,6 +171,33 @@ impl SearchResult {
             })
             .collect::<PyResult<_>>()?;
         Ok(ret)
+    }
+}
+
+impl Searcher {
+    /// Execute an aggregation from an already-deserialized spec.
+    /// Shared by `aggregate()` and `cardinality()` so neither needs to
+    /// round-trip through JSON or Python when the spec is already a
+    /// `serde_json::Value`.
+    fn aggregate_value(
+        &self,
+        py: Python,
+        query: &Query,
+        aggs: tv::aggregation::agg_req::Aggregations,
+    ) -> PyResult<Py<PyDict>> {
+        let agg_res = py.detach(move || {
+            let agg_collector =
+                AggregationCollector::from_aggs(aggs, Default::default());
+            self.inner
+                .search(query.get(), &agg_collector)
+                .map_err(to_pyerr)
+        })?;
+
+        pythonize(py, &agg_res)
+            .map_err(to_pyerr)?
+            .downcast_into::<PyDict>()
+            .map(|d| d.unbind())
+            .map_err(Into::into)
     }
 }
 
@@ -415,6 +443,13 @@ impl Searcher {
         })
     }
 
+    /// Execute an aggregation query and return the results as a dict.
+    ///
+    /// Args:
+    ///     query (Query): The query that filters the documents to aggregate over.
+    ///     agg (dict): The aggregation specification as a Python dict.
+    ///
+    /// Returns a dict containing the aggregation results.
     #[pyo3(signature = (query, agg))]
     fn aggregate(
         &self,
@@ -422,26 +457,9 @@ impl Searcher {
         query: &Query,
         agg: Py<PyDict>,
     ) -> PyResult<Py<PyDict>> {
-        let py_json = py.import("json")?;
-        let agg_query_str = py_json.call_method1("dumps", (agg,))?.to_string();
-
-        let agg_str = py.detach(move || {
-            let agg_collector = AggregationCollector::from_aggs(
-                serde_json::from_str(&agg_query_str).map_err(to_pyerr)?,
-                Default::default(),
-            );
-            let agg_res = self
-                .inner
-                .search(query.get(), &agg_collector)
-                .map_err(to_pyerr)?;
-
-            serde_json::to_string(&agg_res).map_err(to_pyerr)
-        })?;
-
-        let agg_dict = py_json.call_method1("loads", (agg_str,))?;
-        let agg_dict = agg_dict.downcast::<PyDict>()?;
-
-        Ok(agg_dict.clone().unbind())
+        let aggs: tv::aggregation::agg_req::Aggregations =
+            depythonize(agg.bind(py)).map_err(to_pyerr)?;
+        self.aggregate_value(py, query, aggs)
     }
 
     /// Returns the cardinality of a query.
@@ -458,20 +476,16 @@ impl Searcher {
         query: &Query,
         field_name: &str,
     ) -> PyResult<f64> {
-        let py_json = py.import("json")?;
-        let agg_query = serde_json::json!({
+        let agg_spec = serde_json::json!({
             "cardinality": {
                 "cardinality": {
                     "field": field_name,
                 }
             }
         });
-        let agg_query_str =
-            serde_json::to_string(&agg_query).map_err(to_pyerr)?;
-        let agg_query_dict: Py<PyDict> =
-            py_json.call_method1("loads", (agg_query_str,))?.extract()?;
 
-        let agg_res = self.aggregate(py, query, agg_query_dict)?;
+        let aggs = serde_json::from_value(agg_spec).map_err(to_pyerr)?;
+        let agg_res = self.aggregate_value(py, query, aggs)?;
         let agg_res: &Bound<PyDict> = agg_res.bind(py);
 
         let res = agg_res.get_item("cardinality")?.ok_or_else(|| {
@@ -481,9 +495,7 @@ impl Searcher {
         let value = res_dict.get_item("value")?.ok_or_else(|| {
             PyValueError::new_err("Unexpected aggregation result")
         })?;
-        let res = value.extract::<f64>()?;
-
-        Ok(res)
+        value.extract::<f64>()
     }
 
     /// Returns the overall number of documents in the index.

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -404,8 +404,8 @@ class Searcher:
 
     def aggregate(
         self,
-        search_query: Query,
-        agg_query: dict,
+        query: Query,
+        agg: dict,
     ) -> dict:
         pass
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -139,6 +139,39 @@ class TestClass(object):
 }
 """)
 
+    def test_aggregate_terms(self, ram_index_numeric_fields):
+        """terms aggregation on a fast text field returns buckets with doc counts."""
+        index = ram_index_numeric_fields
+        query = Query.all_query()
+        agg_query = {
+            "body_terms": {
+                "terms": {
+                    "field": "body",
+                    "size": 5,
+                }
+            }
+        }
+        searcher = index.searcher()
+        result = searcher.aggregate(query, agg_query)
+
+        assert isinstance(result, dict)
+        assert "body_terms" in result
+        buckets = result["body_terms"]["buckets"]
+        assert len(buckets) == 5  # capped by size=5
+        # Every bucket must have a string key and an integer doc_count
+        for bucket in buckets:
+            assert isinstance(bucket["key"], str)
+            assert isinstance(bucket["doc_count"], int)
+            assert bucket["doc_count"] >= 1
+        # Results are sorted by doc_count descending.
+        counts = [b["doc_count"] for b in buckets]
+        assert counts == sorted(counts, reverse=True)
+        # "and" appears in both documents so it has the highest doc_count (2).
+        # doc1's body has "inthe" as one token (no separate "the"), so "and" wins.
+        top_keys = {b["key"] for b in buckets if b["doc_count"] == buckets[0]["doc_count"]}
+        assert "and" in top_keys
+        assert buckets[0]["doc_count"] == 2
+
     def test_cardinality(self, ram_index_numeric_fields):
         index = ram_index_numeric_fields
         query = Query.all_query()
@@ -156,6 +189,11 @@ class TestClass(object):
         single_doc_query = Query.term_query(index.schema, "id", 1)
         cardinality = searcher.cardinality(single_doc_query, "rating")
         assert cardinality == 1.0
+
+        # Test cardinality on a text fast field - the body field contains
+        # many unique tokens across both documents.
+        cardinality = searcher.cardinality(query, "body")
+        assert cardinality > 10
 
     def test_and_query_numeric_fields(self, ram_index_numeric_fields):
         index = ram_index_numeric_fields
@@ -1803,7 +1841,7 @@ class TestQuery(object):
         index.reload()
         searcher = index.searcher()
 
-        # Exact match on a u64 field — previously always returned 0 hits.
+        # Exact match on a u64 field - previously always returned 0 hits.
         query = Query.term_query(index.schema, "uid", 1)
         result = searcher.search(query, 10)
         assert len(result.hits) == 1, (


### PR DESCRIPTION
aggregate() previously used Python's json module to serialize the input dict to a string, passed it through serde_json::from_str, ran the aggregation, then called serde_json::to_string on the result and json.loads to get back a Python dict — four serialization steps total.

cardinality() had the same problem in reverse: it constructed a serde_json::Value internally with serde_json::json!{}, then serialized it to a JSON string and called json.loads to get a Python dict, just to pass it to aggregate() which immediately depythonized it back.

Replace with a private aggregate_value() helper (in a plain impl block, not exposed to Python) that accepts a serde_json::Value directly and returns a Python dict via pythonize — zero JSON strings on either path. The pythonize crate (v0.26.0) is already a dependency used elsewhere in the codebase (query_grammar.rs, document.rs, schema.rs).

Public API is unchanged:
  aggregate(query, dict) -> dict      (depythonize input, aggregate_value, pythonize output)
  cardinality(query, field) -> f64    (serde_json::json! spec, aggregate_value, extract f64)

Tests added:
  test_aggregate_terms  — terms aggregation on a text fast field, verifying
    bucket structure, key types, sort order, and exact counts
  cardinality on body   — text fast field through the new cardinality path

- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.

AI disclosure: This was located during profiling in paperless-ngx and Claude Code with Sonnet 4.6 suggested the fix.  The Python JSON module's usage showed up when using cProfile against generated test documents.  (I'm also happy to remove it's authorship, if that is a problem)