### PR TITLE
perf: release GIL in Searcher::doc() and doc_freq()

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -466,13 +466,14 @@ impl Searcher {
     #[pyo3(signature = (field_name, field_value))]
     fn doc_freq(
         &self,
+        py: Python,
         field_name: &str,
         field_value: &Bound<PyAny>,
     ) -> PyResult<u64> {
-        // Wrap the tantivy Searcher `doc_freq` method to return a PyResult.
+        // make_term() needs the GIL (Python type extraction); doc_freq() does not.
         let schema = self.inner.schema();
         let term = crate::make_term(schema, field_name, field_value)?;
-        self.inner.doc_freq(&term).map_err(to_pyerr)
+        py.detach(move || self.inner.doc_freq(&term).map_err(to_pyerr))
     }
 
     /// Fetches a document from Tantivy's store given a DocAddress.
@@ -482,12 +483,15 @@ impl Searcher {
     ///         the document that we wish to fetch.
     ///
     /// Returns the Document, raises ValueError if the document can't be found.
-    fn doc(&self, doc_address: &DocAddress) -> PyResult<Document> {
-        let doc: TantivyDocument =
-            self.inner.doc(doc_address.into()).map_err(to_pyerr)?;
-        let named_doc = doc.to_named_doc(self.inner.schema());
-        Ok(crate::document::Document {
-            field_values: named_doc.0,
+    fn doc(&self, py: Python, doc_address: &DocAddress) -> PyResult<Document> {
+        let addr: tv::DocAddress = doc_address.into();
+        py.detach(move || {
+            let doc: TantivyDocument =
+                self.inner.doc(addr).map_err(to_pyerr)?;
+            let named_doc = doc.to_named_doc(self.inner.schema());
+            Ok(crate::document::Document {
+                field_values: named_doc.0,
+            })
         })
     }
 


### PR DESCRIPTION
Both methods previously held the GIL for the duration of their tantivy calls, blocking all other Python threads while potentially reading from the document store or term dictionary (disk I/O on mmap-backed indexes).

doc(): convert DocAddress to tv::DocAddress before py.detach so we hold no Python references inside the GIL-free region, then read the stored document with the GIL released.

doc_freq(): make_term() still runs with the GIL held (it extracts a Python value), but the tantivy doc_freq() call is moved into py.detach.

Same pattern already used by search() and aggregate().

- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.

AI disclosure: Claude Code with Sonnet 4.6 suggested this, though in this case, it wasn't something noticed during integration with paperless-ngx.  (I'm also happy to remove it's authorship, if that is a problem).

Thanks for considering all these PRs.  Even a little taste of Rust has been interesting.  I really should spend some time learning it!