### PR TITLE
Upgrade tantivy to 0.26.0 and drop Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,6 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
             allow-prereleases: false
-          - os: ubuntu-latest
-            python-version: 3.9
-            allow-prereleases: false
     runs-on: "${{ matrix.os }}"
     steps:
       - name: Harden Runner

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,7 @@ jobs:
           manylinux: auto
           target: ${{ matrix.platform }}
           command: build
-          args: --release --sdist -o dist -i 3.9 3.10 3.11 3.12 3.13 3.13t 3.14
+          args: --release --sdist -o dist -i 3.10 3.11 3.12 3.13 3.13t 3.14
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # 7.0.1
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         target: [x64]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.13t', '3.14']
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176
@@ -109,7 +109,7 @@ jobs:
       attestations: write  # persist the attestation
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.13t', '3.14']
         target: ['universal2', 'x86_64-apple-darwin']
     steps:
       - name: Harden Runner

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitpacking"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1d3e2bfd8d06048a179f7b17afc3188effa10385e7b00dc65af6aae732ea92"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
 ]
@@ -235,6 +235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasketches"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
 name = "deranged"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +267,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -298,9 +315,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fs4"
@@ -402,17 +419,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -420,14 +426,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.4+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -445,15 +451,6 @@ name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
-
-[[package]]
-name = "hyperloglogplus"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -492,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,7 +518,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "libc",
 ]
 
@@ -539,12 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
-name = "libm"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,18 +558,18 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 
 [[package]]
 name = "measure_time"
@@ -639,7 +639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -653,6 +652,15 @@ name = "oneshot"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ownedbytes"
@@ -686,15 +694,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "prettyplease"
@@ -810,46 +809,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand",
-]
 
 [[package]]
 name = "rayon"
@@ -986,9 +945,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
 dependencies = [
  "serde",
 ]
@@ -1030,9 +989,25 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.25.0"
+version = "0.26.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "futures",
+ "itertools",
+ "pyo3",
+ "pyo3-build-config 0.28.3",
+ "pythonize",
+ "serde",
+ "serde_json",
+ "tantivy 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tantivy"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545"
+checksum = "778da245841522199d512d19511b041425d8cff3a8f262b4e1516fceb050289a"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -1043,12 +1018,12 @@ dependencies = [
  "census",
  "crc32fast",
  "crossbeam-channel",
+ "datasketches",
  "downcast-rs",
  "fastdivide",
  "fnv",
  "fs4",
  "htmlescape",
- "hyperloglogplus",
  "itertools",
  "levenshtein_automata",
  "log",
@@ -1076,40 +1051,25 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
+ "typetag",
  "uuid",
  "winapi",
 ]
 
 [[package]]
-name = "tantivy"
-version = "0.25.1"
-dependencies = [
- "base64",
- "chrono",
- "futures",
- "itertools",
- "pyo3",
- "pyo3-build-config 0.28.3",
- "pythonize",
- "serde",
- "serde_json",
- "tantivy 0.25.0",
-]
-
-[[package]]
 name = "tantivy-bitpacker"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b04eed5108d8283607da6710fe17a7663523440eaf7ea5a1a440d19a1448b6"
+checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
 dependencies = [
  "bitpacking",
 ]
 
 [[package]]
 name = "tantivy-columnar"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd"
+checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -1123,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-common"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f880aa7cab0c063a47b62596d10991cdd0b6e0e0575d9c5eeb298b307a25de55"
+checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1147,20 +1107,22 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b"
+checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
 dependencies = [
+ "fnv",
  "nom",
+ "ordered-float",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "tantivy-sstable"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5"
+checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
 dependencies = [
  "futures-util",
  "itertools",
@@ -1172,20 +1134,19 @@ dependencies = [
 
 [[package]]
 name = "tantivy-stacker"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d"
+checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
 dependencies = [
  "murmurhash32",
- "rand_distr",
  "tantivy-common",
 ]
 
 [[package]]
 name = "tantivy-tokenizer-api"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038"
+checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
 dependencies = [
  "serde",
 ]
@@ -1203,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -1261,6 +1222,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,17 +1275,11 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "js-sys",
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1603,26 +1588,6 @@ name = "wit-bindgen"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy"
-version = "0.25.1"
+version = "0.26.0"
 readme = "README.md"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2021"
@@ -16,7 +16,7 @@ pyo3-build-config = "0.28.3"
 [dependencies]
 base64 = "0.22"
 chrono = "0.4.44"
-tantivy = "0.25.0"
+tantivy = "0.26.0"
 itertools = "0.14.0"
 futures = "0.3.32"
 pythonize = "0.26.0"

--- a/ci/deploy_mac.sh
+++ b/ci/deploy_mac.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 maturin publish \
-    --interpreter python3.9 \
+    --interpreter python3.10 \
     --username __token__ \
     --password "$MATURIN_PASSWORD" \
     --no-sdist

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"])
+@nox.session(python=["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"])
 def test(session):
     session.install("-r", "requirements-dev.txt")
     session.install("-e", ".", "--no-build-isolation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "maturin"
 
 [project]
 name = "tantivy"
-version = "0.25.1"
+version = "0.26.0"
 description = "Official Python bindings for the Tantivy search engine"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Damir Jelić", email="poljar@termina.org.uk" },
     { name = "Caleb Hattingh", email = "code@cjrh.info" },

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use tantivy as tv;
 use tantivy::aggregation::AggregationCollector;
 use tantivy::collector::{Count, MultiCollector, TopDocs};
+use tantivy::columnar::MonotonicallyMappableToU64;
 use tantivy::TantivyDocument;
 
 // Bring the trait into scope. This is required for the `to_named_doc` method.
@@ -30,14 +31,15 @@ enum Fruit {
     #[pyo3(transparent)]
     Score(f32),
     #[pyo3(transparent)]
-    Order(u64),
+    Order(Option<u64>),
 }
 
 impl std::fmt::Debug for Fruit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Fruit::Score(s) => f.write_str(&format!("{s}")),
-            Fruit::Order(o) => f.write_str(&format!("{o}")),
+            Fruit::Order(Some(o)) => f.write_str(&format!("{o}")),
+            Fruit::Order(None) => f.write_str("None"),
         }
     }
 }
@@ -283,30 +285,73 @@ impl Searcher {
                         }
                     }
                 } else if let Some(order_by) = order_by_field {
-                    let collector =
-                        collector.order_by_u64_field(order_by, order.into());
-                    let top_docs_handle =
-                        multicollector.add_collector(collector);
-                    let ret = self.inner.search(query.get(), &multicollector);
-
-                    match ret {
-                        Ok(mut r) => {
-                            let top_docs = top_docs_handle.extract(&mut r);
-                            let result: Vec<(Fruit, DocAddress)> = top_docs
-                                .iter()
-                                .map(|(f, d)| {
-                                    (Fruit::Order(*f), DocAddress::from(d))
-                                })
-                                .collect();
-                            (r, result)
+                    let schema = self.inner.schema();
+                    let field = crate::get_field(&schema, order_by)
+                        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+                    let field_type =
+                        schema.get_field_entry(field).field_type().value_type();
+                    match field_type {
+                        tv::schema::Type::U64 => {
+                            let top_docs_handle = multicollector.add_collector(
+                                collector.order_by_u64_field(order_by, order.into()),
+                            );
+                            let ret =
+                                self.inner.search(query.get(), &multicollector);
+                            match ret {
+                                Ok(mut r) => {
+                                    let top_docs = top_docs_handle.extract(&mut r);
+                                    let result: Vec<(Fruit, DocAddress)> = top_docs
+                                        .into_iter()
+                                        .map(|(f, d)| {
+                                            (Fruit::Order(f), DocAddress::from(&d))
+                                        })
+                                        .collect();
+                                    (r, result)
+                                }
+                                Err(e) => {
+                                    return Err(PyValueError::new_err(e.to_string()))
+                                }
+                            }
                         }
-                        Err(e) => {
-                            return Err(PyValueError::new_err(e.to_string()))
+                        tv::schema::Type::Date => {
+                            let top_docs_handle = multicollector.add_collector(
+                                collector.order_by_fast_field::<tv::DateTime>(
+                                    order_by,
+                                    order.into(),
+                                ),
+                            );
+                            let ret =
+                                self.inner.search(query.get(), &multicollector);
+                            match ret {
+                                Ok(mut r) => {
+                                    let top_docs = top_docs_handle.extract(&mut r);
+                                    let result: Vec<(Fruit, DocAddress)> = top_docs
+                                        .into_iter()
+                                        .map(|(f, d)| {
+                                            (
+                                                Fruit::Order(f.map(|dt| dt.to_u64())),
+                                                DocAddress::from(&d),
+                                            )
+                                        })
+                                        .collect();
+                                    (r, result)
+                                }
+                                Err(e) => {
+                                    return Err(PyValueError::new_err(e.to_string()))
+                                }
+                            }
+                        }
+                        other => {
+                            return Err(PyValueError::new_err(format!(
+                                "Field '{}' has type {:?}; order_by_field \
+                                 only supports U64 and Date fast fields.",
+                                order_by, other
+                            )));
                         }
                     }
                 } else {
-                    let top_docs_handle =
-                        multicollector.add_collector(collector);
+                    let top_docs_handle = multicollector
+                        .add_collector(collector.order_by_score());
                     let ret = self.inner.search(query.get(), &multicollector);
 
                     match ret {

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -324,8 +324,10 @@ class TestClass(object):
         query = index.parse_query("test")
 
         searcher = index.searcher()
-        result = searcher.search(query, 10, order_by_field="order")
-        assert len(result.hits) == 0
+        with pytest.raises(
+            ValueError, match="not a fast field"
+        ):
+            searcher.search(query, 10, order_by_field="order")
 
     def test_query_explain(self, ram_index):
         index: Index = ram_index


### PR DESCRIPTION
## Summary

- Bump `tantivy` dependency to 0.26.0 and the package to 0.26.0.
- Adapt `src/searcher.rs` to the 0.26 API: `TopDocs` is no longer a `Collector` directly (use `.order_by_score()`); `order_by_u64_field` returns `Vec<(Option<u64>, DocAddress)>` (none-highest natural ordering) and is strict about the declared field type. The Python-facing hit value for ordered searches becomes `Optional[int]`.
- Preserve `order_by_field` support for `Date` fast fields by dispatching on schema type and using `order_by_fast_field::<DateTime>` with the sort key mapped through `MonotonicallyMappableToU64::to_u64()`. Non-U64/Date fast fields now raise a clear `ValueError`.
- Drop Python 3.9 (EOL October 2025) from `requires-python`, `noxfile.py`, CI matrices (`ci.yml`, `publish.yaml`), and `ci/deploy_mac.sh`.

New 0.26 features — regex in query grammar, filter aggregation, and other new aggregation types — are already exposed through the existing `parse_query` and `AggregationCollector` passthroughs, so no new Python API is required.

## Test plan

- [x] `cargo build` clean on tantivy 0.26.0 (pre-existing `delete_documents` deprecation warning and `extract_value` unused import are unrelated to this PR)
- [x] `pytest tests/ --ignore=tests/test_docs.py` — 119 passed
- [x] `test_order_by_search_date` still passes (Date dispatch works)
- [x] `test_order_by_search_without_fast_field` updated to assert the new, earlier `ValueError`
- [ ] CI matrix across 3.10–3.14 on Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)