### PR TITLE
Expose allow_regexes in parse_query

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -510,7 +510,9 @@ impl Index {
     ///         `transpose_cost_one` determines if transpositions of neighbouring characters are counted only once against the Levenshtein distance.
     ///
     ///     conjunction_by_default: If true, the query will be parsed as a conjunction query. Defaults to a disjunction query.
-    #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new(), conjunction_by_default = false))]
+    ///
+    ///     allow_regexes: If true, allow regexes in queries.
+    #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new(), conjunction_by_default = false, allow_regexes = false))]
     pub fn parse_query(
         &self,
         py: Python,
@@ -519,6 +521,7 @@ impl Index {
         field_boosts: HashMap<String, tv::Score>,
         fuzzy_fields: HashMap<String, (bool, u8, bool)>,
         conjunction_by_default: bool,
+        allow_regexes: bool,
     ) -> PyResult<Query> {
         py.detach(move || {
             let parser = self.prepare_query_parser(
@@ -526,6 +529,7 @@ impl Index {
                 field_boosts,
                 fuzzy_fields,
                 conjunction_by_default,
+                allow_regexes
             )?;
 
             let query = parser.parse_query(query).map_err(to_pyerr)?;
@@ -559,10 +563,12 @@ impl Index {
     ///
     ///     conjunction_by_default: If true, the query will be parsed as a conjunction query. Defaults to a disjunction query.
     ///
+    ///     allow_regexes: If true, allow regexes in queries.
+    ///
     /// Returns a tuple containing the parsed query and a list of errors.
     ///
     /// Raises ValueError if a field in `default_field_names` is not defined or marked as indexed.
-    #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new(), conjunction_by_default = false))]
+    #[pyo3(signature = (query, default_field_names = None, field_boosts = HashMap::new(), fuzzy_fields = HashMap::new(), conjunction_by_default = false, allow_regexes = false))]
     pub fn parse_query_lenient(
         &self,
         py: Python,
@@ -571,12 +577,14 @@ impl Index {
         field_boosts: HashMap<String, tv::Score>,
         fuzzy_fields: HashMap<String, (bool, u8, bool)>,
         conjunction_by_default: bool,
+        allow_regexes: bool,
     ) -> PyResult<(Query, Vec<Py<PyAny>>)> {
         let parser = self.prepare_query_parser(
             default_field_names,
             field_boosts,
             fuzzy_fields,
             conjunction_by_default,
+            allow_regexes,
         )?;
 
         let (query, errors) =
@@ -636,6 +644,7 @@ impl Index {
         field_boosts: HashMap<String, tv::Score>,
         fuzzy_fields: HashMap<String, (bool, u8, bool)>,
         conjunction_by_default: bool,
+        allow_regexes: bool,
     ) -> PyResult<tv::query::QueryParser> {
         let schema = self.index.schema();
 
@@ -671,6 +680,10 @@ impl Index {
 
         if conjunction_by_default {
             parser.set_conjunction_by_default();
+        }
+
+        if allow_regexes {
+            parser.allow_regexes();
         }
 
         for (field_name, boost) in field_boosts {

--- a/src/index.rs
+++ b/src/index.rs
@@ -529,7 +529,7 @@ impl Index {
                 field_boosts,
                 fuzzy_fields,
                 conjunction_by_default,
-                allow_regexes
+                allow_regexes,
             )?;
 
             let query = parser.parse_query(query).map_err(to_pyerr)?;

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -513,6 +513,7 @@ class Index:
         field_boosts: Optional[dict[str, float]] = None,
         fuzzy_fields: Optional[dict[str, tuple[bool, int, bool]]] = None,
         conjunction_by_default: bool = False,
+        allow_regexes: bool = False
     ) -> Query:
         pass
 
@@ -523,6 +524,7 @@ class Index:
         field_boosts: Optional[dict[str, float]] = None,
         fuzzy_fields: Optional[dict[str, tuple[bool, int, bool]]] = None,
         conjunction_by_default: bool = False,
+        allow_regexes: bool = False,
     ) -> tuple[Query, list[Any]]:
         pass
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -203,6 +203,22 @@ class TestClass(object):
             == """Query(BooleanQuery { subqueries: [(Should, FuzzyTermQuery { term: Term(field=0, type=Str, "winter"), distance: 1, transposition_cost_one: false, prefix: true }), (Should, TermQuery(Term(field=1, type=Str, "winter")))], minimum_number_should_match: 1 })"""
         )
 
+    def test_parse_query_allow_regexes(self, ram_index):
+        query = ram_index.parse_query("title:/(?:man|men)/", allow_regexes=True)
+        result = ram_index.searcher().search(query, 10)
+        assert len(result.hits) == 2
+        _, doc_address = result.hits[0]
+        searched_doc = ram_index.searcher().doc(doc_address)
+        assert searched_doc["title"] == ["The Old Man and the Sea"]
+        _, doc_address = result.hits[1]
+        searched_doc = ram_index.searcher().doc(doc_address)
+        assert searched_doc["title"] == ["Of Mice and Men"]
+
+        with pytest.raises(
+               ValueError, match="Unsupported query: Regex queries are not allowed."
+          ):
+          query = ram_index.parse_query("title:/(?:man|men)/")
+
     def test_query_errors(self, ram_index):
         index = ram_index
         # no "bod" field
@@ -233,6 +249,10 @@ class TestClass(object):
             == """Query(BooleanQuery { subqueries: [(Should, BooleanQuery { subqueries: [(Must, TermQuery(Term(field=3, type=Str, "hello")))], minimum_number_should_match: 0 })], minimum_number_should_match: 1 })"""
         )
 
+        query, errors = index.parse_query_lenient("title:/(?:man|men)/")
+        assert len(errors) == 1
+        assert isinstance(errors[0], query_parser_error.UnsupportedQueryError)
+        
     def test_order_by_search(self):
         schema = (
             SchemaBuilder()


### PR DESCRIPTION
This PR exposes `allow_regexes` option through parse_query to support regexes in query grammar introduced in tantivy 0.26. The option is disabled by default and needs to be explicitly enabled in `QueryParser`. 


- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.
