### PR TITLE
feat: add Searcher.terms_with_prefix for fast prefix-term lookup

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -5,16 +5,93 @@ use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 use pyo3::{basic::CompareOp, exceptions::PyValueError, prelude::*};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use tantivy as tv;
 use tantivy::aggregation::AggregationCollector;
-use tantivy::collector::{Count, MultiCollector, TopDocs};
+use tantivy::collector::{
+    Collector, Count, MultiCollector, SegmentCollector, TopDocs,
+};
 use tantivy::columnar::MonotonicallyMappableToU64;
+use tantivy::schema::{IndexRecordOption, Type};
 use tantivy::TantivyDocument;
+use tantivy::{DocId, DocSet, Score, SegmentOrdinal, TERMINATED};
 
 // Bring the trait into scope. This is required for the `to_named_doc` method.
 // However, tantivy-py declares its own `Document` class, so we need to avoid
 // introduce the `Document` trait into the namespace.
 use tantivy::Document as _;
+
+/// Returns the smallest byte string strictly greater than `prefix`.
+///
+/// Increments the last non-0xFF byte in place and truncates. Returns None
+/// if every byte is 0xFF (caller must fall back to a manual prefix check).
+fn next_prefix_bound(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut bound = prefix.to_vec();
+    for i in (0..bound.len()).rev() {
+        if bound[i] < 0xFF {
+            bound[i] += 1;
+            bound.truncate(i + 1);
+            return Some(bound);
+        }
+    }
+    None
+}
+
+/// Private collector that gathers matching DocIds per segment.
+///
+/// `merge_fruits` places each segment's HashSet at index `segment_ord` so
+/// `terms_with_prefix` can look up visibility by segment index.
+struct PerSegmentDocSetCollector {
+    num_segments: usize,
+}
+
+struct PerSegmentSegmentCollector {
+    segment_ord: u32,
+    docs: HashSet<DocId>,
+}
+
+impl SegmentCollector for PerSegmentSegmentCollector {
+    type Fruit = (u32, HashSet<DocId>);
+
+    fn collect(&mut self, doc: DocId, _score: Score) {
+        self.docs.insert(doc);
+    }
+
+    fn harvest(self) -> Self::Fruit {
+        (self.segment_ord, self.docs)
+    }
+}
+
+impl Collector for PerSegmentDocSetCollector {
+    type Fruit = Vec<HashSet<DocId>>;
+    type Child = PerSegmentSegmentCollector;
+
+    fn for_segment(
+        &self,
+        segment_local_id: SegmentOrdinal,
+        _reader: &tv::SegmentReader,
+    ) -> tv::Result<Self::Child> {
+        Ok(PerSegmentSegmentCollector {
+            segment_ord: segment_local_id,
+            docs: HashSet::new(),
+        })
+    }
+
+    fn requires_scoring(&self) -> bool {
+        false
+    }
+
+    fn merge_fruits(
+        &self,
+        segment_fruits: Vec<(u32, HashSet<DocId>)>,
+    ) -> tv::Result<Vec<HashSet<DocId>>> {
+        let mut result = vec![HashSet::new(); self.num_segments];
+        for (seg_ord, docs) in segment_fruits {
+            result[seg_ord as usize] = docs;
+        }
+        Ok(result)
+    }
+}
 
 /// Tantivy's Searcher class
 ///
@@ -624,6 +701,144 @@ impl Searcher {
                  Only u64, i64, f64, and bool fast fields are supported."
             ))),
         }
+    }
+
+    /// Walk the term dictionary for `field_name` and return all terms that
+    /// begin with `prefix`, together with their document frequencies.
+    ///
+    /// Args:
+    ///     field_name: Name of an indexed text field in the schema.
+    ///     prefix: Only terms beginning with this string are returned.
+    ///         An empty string returns all terms in the field.
+    ///     filter_query: Optional Query. When provided, each term's count
+    ///         reflects only documents matched by the query (e.g. for
+    ///         permission filtering). Counts are still summed across segments.
+    ///     limit: If given, only the top-`limit` entries (by count) are returned.
+    ///
+    /// Returns:
+    ///     ``[(term, count), ...]`` sorted by count descending, then
+    ///     alphabetically. Terms present in multiple segments have their
+    ///     counts summed.
+    ///
+    /// Raises:
+    ///     ValueError: if the field does not exist or is not a text field.
+    #[pyo3(signature = (field_name, prefix, filter_query = None, limit = None))]
+    fn terms_with_prefix(
+        &self,
+        py: Python,
+        field_name: &str,
+        prefix: &str,
+        filter_query: Option<&Query>,
+        limit: Option<usize>,
+    ) -> PyResult<Vec<(String, u32)>> {
+        let schema = self.inner.schema();
+        let field = crate::get_field(&schema, field_name)?;
+        if !matches!(
+            schema.get_field_entry(field).field_type().value_type(),
+            Type::Str
+        ) {
+            return Err(PyValueError::new_err(format!(
+                "Field '{field_name}' is not an indexed text field."
+            )));
+        }
+
+        let prefix_bytes = prefix.as_bytes().to_vec();
+        let upper_bound = next_prefix_bound(&prefix_bytes);
+        let num_segments = self.inner.segment_readers().len();
+        // When every byte of prefix is 0xFF no FST upper bound can be expressed;
+        // the inner loop falls back to a manual starts_with check.
+        let open_ended = upper_bound.is_none() && !prefix_bytes.is_empty();
+
+        py.detach(move || {
+            let filter_sets: Option<Vec<HashSet<DocId>>> = filter_query
+                .map(|fq| {
+                    self.inner
+                        .search(
+                            fq.get(),
+                            &PerSegmentDocSetCollector { num_segments },
+                        )
+                        .map_err(to_pyerr)
+                })
+                .transpose()?;
+
+            if let Some(ref sets) = filter_sets {
+                if sets.iter().all(|s| s.is_empty()) {
+                    return Ok(vec![]);
+                }
+            }
+
+            let mut counts: HashMap<String, u32> = HashMap::new();
+
+            for (seg_ord, segment_reader) in
+                self.inner.segment_readers().iter().enumerate()
+            {
+                let inv_index =
+                    segment_reader.inverted_index(field).map_err(to_pyerr)?;
+
+                let mut stream = {
+                    let mut builder =
+                        inv_index.terms().range().ge(prefix_bytes.as_slice());
+                    if let Some(ref ub) = upper_bound {
+                        builder = builder.lt(ub.as_slice());
+                    }
+                    builder.into_stream().map_err(to_pyerr)?
+                };
+
+                while stream.advance() {
+                    let key = stream.key();
+                    if open_ended && !key.starts_with(prefix_bytes.as_slice()) {
+                        break;
+                    }
+                    let Ok(term_str) = std::str::from_utf8(key) else {
+                        continue;
+                    };
+
+                    let count = match &filter_sets {
+                        None => stream.value().doc_freq,
+                        Some(filter_sets) => {
+                            let term_info = stream.value().clone();
+                            let mut postings = inv_index
+                                .read_postings_from_terminfo(
+                                    &term_info,
+                                    IndexRecordOption::Basic,
+                                )
+                                .map_err(to_pyerr)?;
+                            debug_assert!(seg_ord < filter_sets.len());
+                            let filter_set = &filter_sets[seg_ord];
+                            let mut c = 0u32;
+                            // SegmentPostings initialises at doc 0; read doc()
+                            // before the first advance().
+                            loop {
+                                let doc = postings.doc();
+                                if doc == TERMINATED {
+                                    break;
+                                }
+                                if filter_set.contains(&doc) {
+                                    c += 1;
+                                }
+                                postings.advance();
+                            }
+                            c
+                        }
+                    };
+
+                    if count > 0 {
+                        *counts.entry(term_str.to_owned()).or_insert(0) +=
+                            count;
+                    }
+                }
+            }
+
+            let mut pairs: Vec<(String, u32)> = counts.into_iter().collect();
+            pairs.sort_by(|(a_term, a_count), (b_term, b_count)| {
+                b_count.cmp(a_count).then_with(|| a_term.cmp(b_term))
+            });
+            if let Some(n) = limit {
+                pairs.truncate(n);
+            }
+
+            Ok(pairs)
+        })
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -430,6 +430,14 @@ class Searcher:
     def doc_freq(self, field_name: str, field_value: Any) -> int:
         pass
 
+    def terms_with_prefix(
+        self,
+        field_name: str,
+        prefix: str,
+        filter_query: Query | None = None,
+        limit: int | None = None,
+    ) -> list[tuple[str, int]]: ...
+
     def cardinality(self, query: Query, field_name: str) -> float:
         pass
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -4,6 +4,8 @@ import copy
 import datetime
 import json
 import pickle
+from itertools import groupby
+
 import pytest
 
 import tantivy
@@ -2123,3 +2125,176 @@ class TestFastFieldValues:
         # Text fast fields store term ids, not scalar values — unsupported.
         with pytest.raises(ValueError, match="unsupported type"):
             searcher.fast_field_values("tag", addrs)
+
+
+class TestTermsWithPrefix:
+    """Tests for Searcher.terms_with_prefix()."""
+
+    @pytest.fixture(scope="class")
+    def prefix_index(self):
+        """Single-segment index with predictable term frequencies."""
+        schema = (
+            SchemaBuilder()
+            .add_text_field("body", stored=False)
+            .add_unsigned_field("owner_id", stored=True, indexed=True, fast=True)
+            .build()
+        )
+        index = Index(schema, None)
+        with index.writer(15_000_000, 1) as writer:
+            # apple: 2 docs, apricot: 1 doc, banana: 1 doc, cherry: 1 doc, date: 1 doc
+            doc = Document()
+            doc.add_text("body", "apple banana")
+            doc.add_unsigned("owner_id", 1)
+            writer.add_document(doc)
+            doc = Document()
+            doc.add_text("body", "apple apricot")
+            doc.add_unsigned("owner_id", 2)
+            writer.add_document(doc)
+            doc = Document()
+            doc.add_text("body", "cherry date")
+            doc.add_unsigned("owner_id", 1)
+            writer.add_document(doc)
+        index.reload()
+        return index
+
+    @pytest.fixture(scope="class")
+    def multi_seg_index(self):
+        """Two-segment index — same 3 docs as prefix_index split across commits.
+
+        wait_merging_threads() is intentionally omitted: calling it lets the
+        default merge policy collapse the two small segments into one, which
+        would defeat the purpose of this fixture.
+        """
+        schema = (
+            SchemaBuilder()
+            .add_text_field("body", stored=False)
+            .build()
+        )
+        index = Index(schema, None)
+        # Two separate commits → two segments (no merge policy invoked yet)
+        with index.writer(15_000_000, 1) as writer:
+            doc = Document()
+            doc.add_text("body", "apple banana")
+            writer.add_document(doc)
+        # Reload between commits forces a new segment on the next write
+        index.reload()
+        with index.writer(15_000_000, 1) as writer:
+            doc = Document()
+            doc.add_text("body", "apple apricot")
+            writer.add_document(doc)
+        index.reload()
+        return index
+
+    @pytest.fixture(scope="class")
+    def filtered_index(self):
+        """4-doc index: 2 owned by user 1, 2 owned by user 2.
+        All docs contain 'apple'; 'exclusive' only in user-2 docs."""
+        schema = (
+            SchemaBuilder()
+            .add_text_field("body", stored=False)
+            .add_unsigned_field("owner_id", stored=True, indexed=True, fast=True)
+            .build()
+        )
+        index = Index(schema, None)
+        with index.writer(15_000_000, 1) as writer:
+            for _ in range(2):
+                doc = Document()
+                doc.add_text("body", "apple common")
+                doc.add_unsigned("owner_id", 1)
+                writer.add_document(doc)
+            for _ in range(2):
+                doc = Document()
+                doc.add_text("body", "apple exclusive")
+                doc.add_unsigned("owner_id", 2)
+                writer.add_document(doc)
+        index.reload()
+        return index
+
+    # ------------------------------------------------------------------ tests
+
+    def test_basic_prefix_match(self, prefix_index):
+        """Returns correct terms and counts for a simple prefix."""
+        searcher = prefix_index.searcher()
+        results = searcher.terms_with_prefix("body", "ap")
+        terms = [t for t, _ in results]
+        counts = {t: c for t, c in results}
+        assert "apple" in terms
+        assert "apricot" in terms
+        assert "banana" not in terms
+        assert counts["apple"] == 2
+        assert counts["apricot"] == 1
+
+    def test_sorted_by_count_descending_then_alpha(self, prefix_index):
+        """Higher-count terms come first; ties broken alphabetically."""
+        searcher = prefix_index.searcher()
+        results = searcher.terms_with_prefix("body", "")  # all terms
+        counts = [c for _, c in results]
+        assert counts == sorted(counts, reverse=True)
+        # Find all terms with the same count and check alphabetical order within
+        for _, group in groupby(results, key=lambda x: x[1]):
+            group_terms = [t for t, _ in group]
+            assert group_terms == sorted(group_terms)
+
+    def test_multi_segment_counts_summed(self, multi_seg_index):
+        """Counts are summed correctly across segments."""
+        assert multi_seg_index.searcher().num_segments >= 2
+        results = multi_seg_index.searcher().terms_with_prefix("body", "ap")
+        counts = {t: c for t, c in results}
+        assert counts["apple"] == 2
+        assert counts["apricot"] == 1
+
+    def test_filter_query_path(self, filtered_index):
+        """filter_query restricts counts to matching docs only."""
+        searcher = filtered_index.searcher()
+        schema = filtered_index.schema
+        filter_q = Query.term_query(schema, "owner_id", 2)
+        # Use empty prefix so all terms are reachable
+        results = searcher.terms_with_prefix("body", "", filter_query=filter_q)
+        counts = {t: c for t, c in results}
+        # user 2 has 2 docs each containing 'apple' and 'exclusive'
+        assert counts.get("apple") == 2
+        assert "common" not in counts
+        assert "exclusive" in counts
+
+    def test_filter_matches_nothing(self, filtered_index):
+        """Returns [] when the filter matches no documents."""
+        searcher = filtered_index.searcher()
+        schema = filtered_index.schema
+        # owner_id 99 does not exist
+        filter_q = Query.term_query(schema, "owner_id", 99)
+        assert searcher.terms_with_prefix("body", "ap", filter_query=filter_q) == []
+
+    def test_limit_truncation(self, prefix_index):
+        """Exactly `limit` results returned, and they are the correct top-N."""
+        searcher = prefix_index.searcher()
+        all_results = searcher.terms_with_prefix("body", "")
+        limited = searcher.terms_with_prefix("body", "", limit=2)
+        assert len(limited) == 2
+        # The top-2 from the full list must equal the limited result
+        assert limited == all_results[:2]
+
+    def test_empty_prefix_returns_all_terms(self, prefix_index):
+        """Empty prefix returns every term in the field."""
+        searcher = prefix_index.searcher()
+        results = searcher.terms_with_prefix("body", "")
+        terms = {t for t, _ in results}
+        assert {"apple", "apricot", "banana", "cherry", "date"} == terms
+
+    def test_unknown_field_raises(self, prefix_index):
+        """ValueError when field_name is not in the schema."""
+        with pytest.raises(ValueError, match="is not defined in the schema"):
+            prefix_index.searcher().terms_with_prefix("nonexistent", "ap")
+
+    def test_non_text_field_raises(self, prefix_index):
+        """ValueError when the field exists but is not a text field."""
+        with pytest.raises(ValueError, match="not an indexed text field"):
+            prefix_index.searcher().terms_with_prefix("owner_id", "ap")
+
+    def test_no_filter_equals_all_docs_filter(self, filtered_index):
+        """filter_query=None and a query matching all docs give identical results
+        including the same ordering."""
+        searcher = filtered_index.searcher()
+        no_filter = searcher.terms_with_prefix("body", "")
+        all_docs_q = filtered_index.parse_query("apple OR common OR exclusive", ["body"])
+        with_filter = searcher.terms_with_prefix("body", "", filter_query=all_docs_q)
+        assert no_filter == with_filter


### PR DESCRIPTION
## Summary

Adds `Searcher.terms_with_prefix(field_name, prefix, filter_query=None, limit=None) -> list[tuple[str, int]]`, which walks the FST term dictionary for a text field and returns all terms beginning with a given prefix, together with their document frequencies summed across segments.

The method never fetches stored documents - it reads only the term dictionary and (in the filtered path) posting lists - making it significantly cheaper than issuing a prefix query and aggregating results.

## Motivation

The primary use case is **permission-scoped autocomplete**: suggest indexed terms to a user while restricting counts to documents they are allowed to see. The optional `filter_query` parameter runs a collector over the index first, builds a per-segment set of matching `DocId`s, and then intersects those sets against each term's posting list. This lets a single call produce correctly-scoped term frequencies without a separate suggestion index.

Other use cases this unlocks:

- **Autocomplete / search-as-you-type** - return ranked term suggestions without fetching documents
- **Faceted sidebar counts** - enumerate `(term, count)` pairs for a prefix as a user narrows a filter
- **Vocabulary exploration** - empty prefix + no limit gives the full frequency-ranked vocabulary for a field
- **Query expansion** - enumerate indexed variants before building a broad boolean OR query
- **Corpus debugging** - inspect what terms actually landed in a field after tokenization

## API

```python
searcher.terms_with_prefix(
    field_name: str,
    prefix: str,
    filter_query: Query | None = None,
    limit: int | None = None,
) -> list[tuple[str, int]]
```

- `prefix=""` returns all terms in the field.
- Results are sorted by count descending, then alphabetically for ties.
- Counts are summed across segments, so multi-segment indexes are handled transparently.
- Raises `ValueError` if the field does not exist or is not a text field.

## Implementation notes

- **FST range query** - the upper bound for the prefix scan is computed by `next_prefix_bound`, which increments the last non-`0xFF` byte and truncates. When all bytes are `0xFF`, no FST upper bound can be expressed and the loop falls back to a manual `starts_with` check.
- **Filtered path** - a private `PerSegmentDocSetCollector` implements tantivy's `Collector` trait to gather `HashSet<DocId>` per segment ordinal. This avoids allocating a single global set and lets Phase 2 index directly by segment.
- **GIL release** - the entire body after field validation runs under `py.detach`, consistent with `Searcher::doc` and `doc_freq`.
- **Early exit** - when a `filter_query` is provided but matches no documents, the method returns `[]` immediately without walking any segment's term dictionary.

## Changes

| File | Change |
|---|---|
| `src/searcher.rs` | `next_prefix_bound` helper, `PerSegmentDocSetCollector` + impls, `terms_with_prefix` method on `Searcher` |
| `tantivy/tantivy.pyi` | Type stub for `terms_with_prefix` |
| `tests/tantivy_test.py` | `TestTermsWithPrefix`: 10 tests across 3 fixtures covering prefix match, multi-segment count summing, filter query, empty-filter early exit, limit truncation, sort order, error cases |

## AI disclosure

This PR was developed with Claude Code assistance. All code has been reviewed as best I can.  Overall, most of the additions are tests to ensure the code works as expected.  Those look good to me.

- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.
