### PR TITLE
fix: add_date loses tzinfo

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -33,6 +33,12 @@ use std::{
 /// are normalized via `astimezone(timezone.utc)`, which handles fixed-offset
 /// and IANA tzinfos (e.g. `zoneinfo.ZoneInfo`). Naive inputs are interpreted
 /// as UTC, matching tantivy's documented "implicitly UTC" convention.
+///
+/// The `astimezone` round-trip is required because pyo3's chrono `FromPyObject`
+/// impls are strict: `NaiveDateTime` rejects any input with tzinfo, and
+/// `DateTime<Utc>` only accepts inputs whose tzinfo *is* `datetime.timezone.utc`
+/// — a `zoneinfo.ZoneInfo("UTC")` or any non-UTC tz fails. Normalizing in
+/// Python first sidesteps both restrictions.
 fn pydatetime_to_tv(any: &Bound<PyAny>) -> PyResult<tv::DateTime> {
     let dt = any.downcast::<PyDateTime>()?;
     let nanos = if dt.get_tzinfo().is_some() {

--- a/src/document.rs
+++ b/src/document.rs
@@ -6,13 +6,13 @@ use pyo3::{
     basic::CompareOp,
     prelude::*,
     types::{
-        PyAny, PyBool, PyDateAccess, PyDateTime, PyDict, PyInt, PyList,
-        PyTimeAccess, PyTuple,
+        PyAny, PyBool, PyDateTime, PyDict, PyInt, PyList, PyTuple, PyTzInfo,
+        PyTzInfoAccess,
     },
     IntoPyObjectExt, Python,
 };
 
-use chrono::{offset::TimeZone, NaiveDateTime, Utc};
+use chrono::{DateTime as ChronoDateTime, NaiveDateTime, Utc};
 
 use tantivy::{self as tv, schema::document::OwnedValue as Value};
 
@@ -27,6 +27,35 @@ use std::{
     str::FromStr,
 };
 
+/// Convert a Python `datetime` (naive or aware) to a tantivy `DateTime`.
+///
+/// Tantivy stores timestamps as UTC nanoseconds with no tzinfo. Aware inputs
+/// are normalized via `astimezone(timezone.utc)`, which handles fixed-offset
+/// and IANA tzinfos (e.g. `zoneinfo.ZoneInfo`). Naive inputs are interpreted
+/// as UTC, matching tantivy's documented "implicitly UTC" convention.
+fn pydatetime_to_tv(any: &Bound<PyAny>) -> PyResult<tv::DateTime> {
+    let dt = any.downcast::<PyDateTime>()?;
+    let nanos = if dt.get_tzinfo().is_some() {
+        let utc_tz = PyTzInfo::utc(dt.py())?;
+        let utc_dt = dt.call_method1("astimezone", (utc_tz,))?;
+        utc_dt
+            .extract::<ChronoDateTime<Utc>>()?
+            .timestamp_nanos_opt()
+    } else {
+        any.extract::<NaiveDateTime>()?
+            .and_utc()
+            .timestamp_nanos_opt()
+    }
+    .ok_or_else(|| to_pyerr("datetime out of representable range"))?;
+    Ok(tv::DateTime::from_timestamp_nanos(nanos))
+}
+
+/// Convert a tantivy `DateTime` to a tz-aware UTC Python `datetime`.
+fn tv_to_pydatetime(py: Python, dt: tv::DateTime) -> PyResult<Py<PyAny>> {
+    ChronoDateTime::<Utc>::from_timestamp_nanos(dt.into_timestamp_nanos())
+        .into_py_any(py)
+}
+
 pub(crate) fn extract_value(any: &Bound<PyAny>) -> PyResult<Value> {
     if let Ok(s) = any.extract::<String>() {
         return Ok(Value::Str(s));
@@ -40,10 +69,8 @@ pub(crate) fn extract_value(any: &Bound<PyAny>) -> PyResult<Value> {
     if let Ok(num) = any.extract::<f64>() {
         return Ok(Value::F64(num));
     }
-    if let Ok(datetime) = any.extract::<NaiveDateTime>() {
-        return Ok(Value::Date(tv::DateTime::from_timestamp_secs(
-            datetime.and_utc().timestamp(),
-        )));
+    if any.downcast::<PyDateTime>().is_ok() {
+        return Ok(Value::Date(pydatetime_to_tv(any)?));
     }
     if let Ok(facet) = any.extract::<Facet>() {
         return Ok(Value::Facet(facet.inner));
@@ -105,15 +132,10 @@ pub(crate) fn extract_value_for_type(
             any.extract::<f64>()
                 .map_err(to_pyerr_for_type("F64", field_name, any))?,
         ),
-        tv::schema::Type::Date => {
-            let datetime = any
-                .extract::<NaiveDateTime>()
-                .map_err(to_pyerr_for_type("DateTime", field_name, any))?;
-
-            Value::Date(tv::DateTime::from_timestamp_secs(
-                datetime.and_utc().timestamp(),
-            ))
-        }
+        tv::schema::Type::Date => Value::Date(
+            pydatetime_to_tv(any)
+                .map_err(to_pyerr_for_type("DateTime", field_name, any))?,
+        ),
         tv::schema::Type::Facet => Value::Facet(
             any.extract::<Facet>()
                 .map_err(to_pyerr_for_type("Facet", field_name, any))?
@@ -226,21 +248,7 @@ fn value_to_py(py: Python, value: &Value) -> PyResult<Py<PyAny>> {
             // TODO implement me
             unimplemented!();
         }
-        Value::Date(d) => {
-            let utc = d.into_utc();
-            PyDateTime::new(
-                py,
-                utc.year(),
-                utc.month() as u8,
-                utc.day(),
-                utc.hour(),
-                utc.minute(),
-                utc.second(),
-                utc.microsecond(),
-                None,
-            )?
-            .into_py_any(py)?
-        }
+        Value::Date(d) => tv_to_pydatetime(py, *d)?,
         Value::Facet(f) => Facet { inner: f.clone() }.into_py_any(py)?,
         Value::Array(arr) => {
             let list = PyList::empty(py);
@@ -719,22 +727,14 @@ impl Document {
     /// Args:
     ///     field_name (str): The field name for which we are adding the date.
     ///     value (datetime): The date that will be added to the document.
-    fn add_date(&mut self, field_name: String, value: &Bound<PyDateTime>) {
-        let datetime = Utc
-            .with_ymd_and_hms(
-                value.get_year(),
-                value.get_month().into(),
-                value.get_day().into(),
-                value.get_hour().into(),
-                value.get_minute().into(),
-                value.get_second().into(),
-            )
-            .single()
-            .unwrap();
-        self.add_value(
-            field_name,
-            tv::DateTime::from_timestamp_secs(datetime.timestamp()),
-        );
+    fn add_date(
+        &mut self,
+        field_name: String,
+        value: &Bound<PyDateTime>,
+    ) -> PyResult<()> {
+        let dt = pydatetime_to_tv(value.as_any())?;
+        self.add_value(field_name, dt);
+        Ok(())
     }
 
     /// Add a facet value to the document.

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -794,7 +794,27 @@ class TestDocument(object):
     def test_document_with_date(self):
         date = datetime.datetime(2019, 8, 12, 13, 0, 0)
         doc = tantivy.Document(name="Bill", date=date)
-        assert doc["date"][0] == date
+        assert doc["date"][0] == date.replace(tzinfo=datetime.timezone.utc)
+
+    def test_document_with_aware_date(self):
+        eastern = datetime.timezone(datetime.timedelta(hours=-5))
+        date = datetime.datetime(2019, 8, 12, 13, 0, 0, tzinfo=eastern)
+        doc = tantivy.Document(name="Bill", date=date)
+        assert doc["date"][0] == date.astimezone(datetime.timezone.utc)
+
+    def test_document_with_offset_date_normalizes_to_utc(self):
+        ist = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
+        date = datetime.datetime(2019, 8, 12, 13, 0, 0, tzinfo=ist)
+        doc = tantivy.Document(name="Bill", date=date)
+        expected = datetime.datetime(
+            2019, 8, 12, 7, 30, 0, tzinfo=datetime.timezone.utc
+        )
+        assert doc["date"][0] == expected
+
+    def test_document_date_microseconds_preserved(self):
+        date = datetime.datetime(2019, 8, 12, 13, 0, 0, 123456)
+        doc = tantivy.Document(name="Bill", date=date)
+        assert doc["date"][0] == date.replace(tzinfo=datetime.timezone.utc)
 
     def test_document_repr(self):
         doc = tantivy.Document(name="Bill", reference=[1, 2])

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -463,6 +463,48 @@ class TestClass(object):
         searched_doc = index.searcher().doc(doc_address)
         assert searched_doc["title"] == ["Test title"]
 
+    def test_date_index_roundtrip(self):
+        schema = (
+            SchemaBuilder()
+            .add_date_field("date", stored=True, indexed=True)
+            .add_text_field("title", stored=True)
+            .build()
+        )
+        index = Index(schema)
+        writer = index.writer()
+
+        naive = datetime.datetime(2019, 8, 12, 13, 0, 0, 123456)
+        ist = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
+        aware = datetime.datetime(2019, 8, 12, 13, 0, 0, tzinfo=ist)
+
+        doc = Document()
+        doc.add_text("title", "naive")
+        doc.add_date("date", naive)
+        writer.add_document(doc)
+
+        doc = Document()
+        doc.add_text("title", "aware")
+        doc.add_date("date", aware)
+        writer.add_document(doc)
+
+        writer.commit()
+        index.reload()
+        searcher = index.searcher()
+
+        query = index.parse_query("naive OR aware", ["title"])
+        hits = searcher.search(query, 10).hits
+        by_title = {
+            searcher.doc(addr)["title"][0]: searcher.doc(addr)["date"][0]
+            for _, addr in hits
+        }
+
+        assert by_title["naive"] == naive.replace(
+            tzinfo=datetime.timezone.utc
+        )
+        assert by_title["aware"] == datetime.datetime(
+            2019, 8, 12, 7, 30, 0, tzinfo=datetime.timezone.utc
+        )
+
     def test_with_merges(self):
         # This test is taken from tantivy's test suite:
         # https://github.com/quickwit-oss/tantivy/blob/42acd334f49d5ff7e4fe846b5c12198f24409b50/src/indexer/index_writer.rs#L1130


### PR DESCRIPTION
# Breaking change

During write, this will correctly convert an incoming Python datetime into UTC by taking the tzinfo into account.  During read, a tz-aware datetime object is returned, with UTC set.

- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.
