### PR TITLE
Add license to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.9.3,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -7,6 +7,8 @@ name = "tantivy"
 version = "0.26.0"
 description = "Official Python bindings for the Tantivy search engine"
 requires-python = ">=3.10"
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "Damir Jelić", email="poljar@termina.org.uk" },
     { name = "Caleb Hattingh", email = "code@cjrh.info" },


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.

I noticed that no license is exposed in PyPI or deps.dev so I added license and license-files rows and bumped maturin to 1.9.3 for PEP 639.