### PR TITLE
feat: support JSON subpaths in programmatic term-query constructors

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -184,6 +184,37 @@ complex_query = Query.boolean_query(
 
 <!--TODO: Update the reference link to the query parser docs when available.-->
 
+## Querying JSON fields programmatically
+
+`Query.term_query` (and `term_set_query`, `phrase_query`, `phrase_prefix_query`,
+`Searcher.doc_freq`) accept a JSON subpath as `field_name`, the same paths
+`index.parse_query()` understands:
+
+```python
+from tantivy import SchemaBuilder, Index, Query, Document
+
+json_schema = SchemaBuilder().add_json_field("attrs", stored=True).build()
+json_index = Index(json_schema)
+json_writer = json_index.writer()
+json_doc = Document()
+json_doc.add_json("attrs", {"user": "alice", "count": 5})
+json_writer.add_document(json_doc)
+json_writer.commit()
+json_index.reload()
+
+json_query = Query.term_query(json_schema, "attrs.user", "alice")
+json_result = json_index.searcher().search(json_query, 10)
+assert len(json_result.hits) == 1
+```
+
+A field literally named `"attrs.user"` always takes precedence over the
+subpath interpretation. A path given for a field that isn't JSON, or a root
+that doesn't resolve to any field, raises `ValueError`. A JSON string value
+that looks like a number, bool, or date (e.g. `"5"`) is matched as that typed
+value, not as literal text — unlike `index.parse_query()`, which tries both.
+If you need to match such a string literally, use `index.parse_query()`
+instead.
+
 ## Combining Queries with the Boolean Helper Methods
 
 `Query.boolean_query(...)` shown above is the most general way to combine

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod searcher;
 mod snippet;
 mod tokenizer;
 
-use document::{extract_value_for_type, Document};
+use document::{extract_value, extract_value_for_type, Document};
 use explanation::Explanation;
 use facet::Facet;
 use index::{Index, IndexWriter};
@@ -169,7 +169,48 @@ pub(crate) fn make_term(
     field_name: &str,
     field_value: &Bound<PyAny>,
 ) -> PyResult<tv::Term> {
-    let field = get_field(schema, field_name)?;
+    make_term_impl(schema, field_name, field_value, false)
+}
+
+/// Like `make_term`, but for a single word inside a phrase
+/// (`Query.phrase_query` / `Query.phrase_prefix_query`). For a JSON subpath,
+/// a phrase word is always treated as text, never as a typed fast value —
+/// mirroring tantivy's own query parser, which only ever tokenizes phrase
+/// content as text. Without this, a phrase word that happens to look
+/// numeric/bool/date-like (e.g. "5") would silently become an untokenized
+/// typed term that can never match the indexed text posting for that word.
+pub(crate) fn make_term_for_phrase_word(
+    schema: &tv::schema::Schema,
+    field_name: &str,
+    field_value: &Bound<PyAny>,
+) -> PyResult<tv::Term> {
+    make_term_impl(schema, field_name, field_value, true)
+}
+
+fn make_term_impl(
+    schema: &tv::schema::Schema,
+    field_name: &str,
+    field_value: &Bound<PyAny>,
+    json_path_text_only: bool,
+) -> PyResult<tv::Term> {
+    let (field, json_path) =
+        schema.find_field(field_name).ok_or_else(|| {
+            exceptions::PyValueError::new_err(format!(
+                "Field `{field_name}` is not defined in the schema."
+            ))
+        })?;
+
+    if !json_path.is_empty() {
+        return make_json_path_term(
+            schema,
+            field,
+            field_name,
+            json_path,
+            field_value,
+            json_path_text_only,
+        );
+    }
+
     // Look up the actual field type from the schema so that Python integers
     // are extracted as the correct numeric type (u64 vs i64).  The generic
     // extract_value() path always infers integers as i64 because Python ints
@@ -192,6 +233,100 @@ pub(crate) fn make_term(
             )))
         }
     };
+
+    Ok(term)
+}
+
+/// Builds a `Term` addressing a JSON subpath, e.g. `field_name` = `"notes.user"`
+/// resolving to the `notes` field with `json_path` `"user"`.
+///
+/// A JSON field has no single declared value type, so unlike the plain-field
+/// path in `make_term`, the Python value is read with its own type
+/// (`extract_value`) rather than coerced to a schema-declared one. Numeric and
+/// string handling mirrors tantivy's query parser (`generate_literals_for_json_object`
+/// in `query_parser.rs`): a string is first tried as a typed fast value
+/// (int/float/bool/date) and only kept as text if that fails; a float that is
+/// a whole number is normalized to the same int representation the JSON
+/// indexer would have stored it as.
+///
+/// When `text_only` is set (phrase words), a string value is always kept as
+/// text and never reinterpreted as a typed fast value.
+fn make_json_path_term(
+    schema: &tv::schema::Schema,
+    field: tv::schema::Field,
+    field_name: &str,
+    json_path: &str,
+    field_value: &Bound<PyAny>,
+    text_only: bool,
+) -> PyResult<tv::Term> {
+    let json_options = match schema.get_field_entry(field).field_type() {
+        tv::schema::FieldType::JsonObject(json_options) => json_options,
+        _ => {
+            return Err(exceptions::PyValueError::new_err(format!(
+                "Field `{field_name}` is not defined in the schema."
+            )))
+        }
+    };
+
+    let mut term = Term::from_field_json_path(
+        field,
+        json_path,
+        json_options.is_expand_dots_enabled(),
+    );
+
+    let value = if !field_value.is_instance_of::<pyo3::types::PyBool>()
+        && field_value.extract::<i64>().is_err()
+    {
+        // extract_value() only ever produces Value::I64 for Python ints (it
+        // tries i64, then falls through to f64), which silently loses
+        // precision for ints between i64::MAX and u64::MAX -- the JSON
+        // indexer itself stores such a value as u64. Intercept that one case
+        // before generic extraction.
+        match field_value.extract::<u64>() {
+            Ok(num) => Value::U64(num),
+            Err(_) => extract_value(field_value)?,
+        }
+    } else {
+        extract_value(field_value)?
+    };
+    match value {
+        Value::Str(text) => {
+            if text_only {
+                term.append_type_and_str(&text);
+            } else {
+                match tv::json_utils::convert_to_fast_value_and_append_to_json_term(
+                    &term, &text, true,
+                ) {
+                    Some(fast_term) => term = fast_term,
+                    None => term.append_type_and_str(&text),
+                }
+            }
+        }
+        Value::U64(num) => term.append_type_and_fast_value(num),
+        Value::Bool(b) => term.append_type_and_fast_value(b),
+        Value::I64(num) => term.append_type_and_fast_value(num),
+        Value::F64(num) => {
+            match tv::columnar::NumericalValue::F64(num).normalize() {
+                tv::columnar::NumericalValue::I64(v) => {
+                    term.append_type_and_fast_value(v)
+                }
+                tv::columnar::NumericalValue::U64(v) => {
+                    term.append_type_and_fast_value(v)
+                }
+                tv::columnar::NumericalValue::F64(v) => {
+                    term.append_type_and_fast_value(v)
+                }
+            }
+        }
+        Value::Date(d) => {
+            term.append_type_and_fast_value(d.truncate(tv::schema::DATE_TIME_PRECISION_INDEXED))
+        }
+        _ => {
+            return Err(exceptions::PyValueError::new_err(format!(
+                "Can't create a term for Field `{field_name}` with value `{field_value}`."
+            )))
+        }
+    }
 
     Ok(term)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,14 +172,14 @@ pub(crate) fn make_term(
     make_term_impl(schema, field_name, field_value, false)
 }
 
-/// Like `make_term`, but for a single word inside a phrase
-/// (`Query.phrase_query` / `Query.phrase_prefix_query`). For a JSON subpath,
-/// a phrase word is always treated as text, never as a typed fast value —
-/// mirroring tantivy's own query parser, which only ever tokenizes phrase
-/// content as text. Without this, a phrase word that happens to look
-/// numeric/bool/date-like (e.g. "5") would silently become an untokenized
-/// typed term that can never match the indexed text posting for that word.
-pub(crate) fn make_term_for_phrase_word(
+/// Like `make_term`, but always treats a JSON subpath value as text, never
+/// as a typed fast value. Used for phrase words (`Query.phrase_query` /
+/// `Query.phrase_prefix_query`) and for `Query.fuzzy_term_query`, which are
+/// both text-only operations — mirroring tantivy's own query parser, which
+/// only ever tokenizes phrase content as text. Without this, a value that
+/// happens to look numeric/bool/date-like (e.g. "5") would silently become
+/// an untokenized typed term that can never match the indexed text posting.
+pub(crate) fn make_term_text_only(
     schema: &tv::schema::Schema,
     field_name: &str,
     field_value: &Bound<PyAny>,
@@ -243,13 +243,13 @@ fn make_term_impl(
 /// A JSON field has no single declared value type, so unlike the plain-field
 /// path in `make_term`, the Python value is read with its own type
 /// (`extract_value`) rather than coerced to a schema-declared one. Numeric and
-/// string handling mirrors tantivy's query parser (`generate_literals_for_json_object`
-/// in `query_parser.rs`): a string is first tried as a typed fast value
+/// string handling mirrors tantivy's JSON indexing path (`index_json_value`
+/// in `json_utils.rs`): a string is first tried as a typed fast value
 /// (int/float/bool/date) and only kept as text if that fails; a float that is
 /// a whole number is normalized to the same int representation the JSON
 /// indexer would have stored it as.
 ///
-/// When `text_only` is set (phrase words), a string value is always kept as
+/// When `text_only` is set (phrase words, fuzzy queries), a string value is always kept as
 /// text and never reinterpreted as a typed fast value.
 fn make_json_path_term(
     schema: &tv::schema::Schema,
@@ -306,6 +306,14 @@ fn make_json_path_term(
         Value::Bool(b) => term.append_type_and_fast_value(b),
         Value::I64(num) => term.append_type_and_fast_value(num),
         Value::F64(num) => {
+            // The JSON indexer never writes a term for a non-finite float
+            // (`json_utils.rs`'s leaf indexing silently drops it), so a term
+            // built from one here could never match anything indexed.
+            if !num.is_finite() {
+                return Err(exceptions::PyValueError::new_err(format!(
+                    "Can't create a term for Field `{field_name}` with non-finite value `{field_value}`."
+                )));
+            }
             match tv::columnar::NumericalValue::F64(num).normalize() {
                 tv::columnar::NumericalValue::I64(v) => {
                     term.append_type_and_fast_value(v)

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,7 @@
 use crate::{
     document::Document, explanation::Explanation, get_field, make_term,
-    make_term_for_type, schema::FieldType, searcher::Searcher, to_pyerr,
-    DocAddress, Schema,
+    make_term_for_phrase_word, make_term_for_type, schema::FieldType,
+    searcher::Searcher, to_pyerr, DocAddress, Schema,
 };
 use core::ops::Bound as OpsBound;
 use pyo3::{
@@ -180,6 +180,26 @@ impl Query {
     }
 
     /// Construct a Tantivy's TermQuery
+    ///
+    /// # Arguments
+    ///
+    /// * `schema` - Schema of the target index.
+    /// * `field_name` - Field name to be searched. For a JSON field, this may
+    ///   be a subpath, e.g. `"attrs.user"` to address the `user` key inside a
+    ///   JSON field named `attrs`. A field literally named `"attrs.user"`
+    ///   takes precedence over the subpath interpretation.
+    /// * `field_value` - The value to search for. Not tokenized: pre-tokenize
+    ///   to match the index's tokenizer if the field is analyzed text.
+    /// * `index_option` - (Optional) One of `'basic'`, `'freq'` or `'position'`.
+    ///
+    /// For a JSON field, a string `field_value` that parses as a number,
+    /// bool, or RFC3339 date is interpreted as that typed value — matching
+    /// how such a value would have been indexed — not as literal text. A
+    /// JSON string leaf whose content happens to look numeric/bool/date-like
+    /// (e.g. the string `"5"`) is therefore currently not reachable through
+    /// `term_query`; `index.parse_query()` can match it because the query
+    /// parser tries both interpretations, but a single `Term` cannot
+    /// represent that union.
     #[staticmethod]
     #[pyo3(signature = (schema, field_name, field_value, index_option = "position"))]
     pub(crate) fn term_query(
@@ -204,6 +224,8 @@ impl Query {
     }
 
     /// Construct a Tantivy's TermSetQuery
+    ///
+    /// `field_name` accepts a JSON subpath the same way `term_query` does.
     #[staticmethod]
     #[pyo3(signature = (schema, field_name, field_values))]
     pub(crate) fn term_set_query(
@@ -266,7 +288,10 @@ impl Query {
     /// # Arguments
     ///
     /// * `schema` - Schema of the target index.
-    /// * `field_name` - Field name to be searched.
+    /// * `field_name` - Field name to be searched. For a JSON field, this may
+    ///   be a subpath, e.g. `"attrs.user"`, the same way `term_query` accepts
+    ///   one. On a JSON subpath, `text` is always matched as text, never as a
+    ///   typed fast value, since fuzzy matching only makes sense on text.
     /// * `text` - String representation of the query term.
     /// * `distance` - (Optional) Edit distance you are going to allow. When not specified, the default is 1.
     /// * `transposition_cost_one` - (Optional) If true, a transposition (swapping) cost will be 1; otherwise it will be 2. When not specified, the default is true.
@@ -281,7 +306,7 @@ impl Query {
         transposition_cost_one: bool,
         prefix: bool,
     ) -> PyResult<Query> {
-        let term = make_term(&schema.inner, field_name, text)?;
+        let term = make_term_for_phrase_word(&schema.inner, field_name, text)?;
         let inner = if prefix {
             tv::query::FuzzyTermQuery::new_prefix(
                 term,
@@ -305,7 +330,8 @@ impl Query {
     /// # Arguments
     ///
     /// * `schema` - Schema of the target index.
-    /// * `field_name` - Field name to be searched.
+    /// * `field_name` - Field name to be searched. For a JSON field, this may
+    ///   be a subpath, e.g. `"attrs.description"`.
     /// * `words` - Word list that constructs the phrase. A word can be a term text or a pair of term text and its offset in the phrase.
     /// * `slop` - (Optional) The number of gaps permitted between the words in the query phrase. Default is 0.
     #[staticmethod]
@@ -320,11 +346,19 @@ impl Query {
         for (idx, word) in words.into_iter().enumerate() {
             if let Ok((offset, value)) = word.extract() {
                 // Custom offset is provided.
-                let term = make_term(&schema.inner, field_name, &value)?;
+                let term = make_term_for_phrase_word(
+                    &schema.inner,
+                    field_name,
+                    &value,
+                )?;
                 terms_with_offset.push((offset, term));
             } else {
                 // Custom offset is not provided. Use the list index as the offset.
-                let term = make_term(&schema.inner, field_name, &word)?;
+                let term = make_term_for_phrase_word(
+                    &schema.inner,
+                    field_name,
+                    &word,
+                )?;
                 terms_with_offset.push((idx, term));
             };
         }
@@ -394,7 +428,8 @@ impl Query {
     /// # Arguments
     ///
     /// * `schema` - Schema of the target index.
-    /// * `field_name` - Field name to be searched.
+    /// * `field_name` - Field name to be searched. For a JSON field, this may
+    ///   be a subpath, e.g. `"attrs.description"`.
     /// * `words` - Word list that constructs the phrase. A word can be a term text or a pair of term text and its offset in the phrase.
     #[staticmethod]
     #[pyo3(signature = (schema, field_name, words))]
@@ -407,11 +442,19 @@ impl Query {
         for (idx, word) in words.into_iter().enumerate() {
             if let Ok((offset, value)) = word.extract() {
                 // Custom offset is provided.
-                let term = make_term(&schema.inner, field_name, &value)?;
+                let term = make_term_for_phrase_word(
+                    &schema.inner,
+                    field_name,
+                    &value,
+                )?;
                 terms_with_offset.push((offset, term));
             } else {
                 // Custom offset is not provided. Use the list index as the offset.
-                let term = make_term(&schema.inner, field_name, &word)?;
+                let term = make_term_for_phrase_word(
+                    &schema.inner,
+                    field_name,
+                    &word,
+                )?;
                 terms_with_offset.push((idx, term));
             };
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,6 @@
 use crate::{
     document::Document, explanation::Explanation, get_field, make_term,
-    make_term_for_phrase_word, make_term_for_type, schema::FieldType,
+    make_term_for_type, make_term_text_only, schema::FieldType,
     searcher::Searcher, to_pyerr, DocAddress, Schema,
 };
 use core::ops::Bound as OpsBound;
@@ -306,7 +306,7 @@ impl Query {
         transposition_cost_one: bool,
         prefix: bool,
     ) -> PyResult<Query> {
-        let term = make_term_for_phrase_word(&schema.inner, field_name, text)?;
+        let term = make_term_text_only(&schema.inner, field_name, text)?;
         let inner = if prefix {
             tv::query::FuzzyTermQuery::new_prefix(
                 term,
@@ -346,19 +346,13 @@ impl Query {
         for (idx, word) in words.into_iter().enumerate() {
             if let Ok((offset, value)) = word.extract() {
                 // Custom offset is provided.
-                let term = make_term_for_phrase_word(
-                    &schema.inner,
-                    field_name,
-                    &value,
-                )?;
+                let term =
+                    make_term_text_only(&schema.inner, field_name, &value)?;
                 terms_with_offset.push((offset, term));
             } else {
                 // Custom offset is not provided. Use the list index as the offset.
-                let term = make_term_for_phrase_word(
-                    &schema.inner,
-                    field_name,
-                    &word,
-                )?;
+                let term =
+                    make_term_text_only(&schema.inner, field_name, &word)?;
                 terms_with_offset.push((idx, term));
             };
         }
@@ -442,19 +436,13 @@ impl Query {
         for (idx, word) in words.into_iter().enumerate() {
             if let Ok((offset, value)) = word.extract() {
                 // Custom offset is provided.
-                let term = make_term_for_phrase_word(
-                    &schema.inner,
-                    field_name,
-                    &value,
-                )?;
+                let term =
+                    make_term_text_only(&schema.inner, field_name, &value)?;
                 terms_with_offset.push((offset, term));
             } else {
                 // Custom offset is not provided. Use the list index as the offset.
-                let term = make_term_for_phrase_word(
-                    &schema.inner,
-                    field_name,
-                    &word,
-                )?;
+                let term =
+                    make_term_text_only(&schema.inner, field_name, &word)?;
                 terms_with_offset.push((idx, term));
             };
         }

--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -5,7 +5,7 @@ use pyo3::{exceptions, prelude::*};
 use crate::schema::Schema;
 use std::sync::{Arc, RwLock};
 use tantivy::schema::{
-    self, BytesOptions, DateOptions, IpAddrOptions, INDEXED,
+    self, BytesOptions, DateOptions, IpAddrOptions, JsonObjectOptions, INDEXED,
 };
 
 /// Tantivy has a very strict schema.
@@ -325,6 +325,13 @@ impl SchemaBuilder {
     ///         document id and the term frequency, while the 'position' option
     ///         records the document id, term frequency and the positions of
     ///         the term occurrences in the document.
+    ///     expand_dots_enabled (bool, optional): If true, a "." in a JSON
+    ///         object key is treated as a path separator, the same as a "."
+    ///         between keys in a query string or in `field_name` passed to
+    ///         `Query.term_query`. E.g. `{"a.b": "hello"}` is then indexed as
+    ///         if it was `{"a": {"b": "hello"}}`, reachable via `attrs.a.b`
+    ///         instead of the default `attrs.a\.b` escaped form. Defaults to
+    ///         False.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -333,7 +340,8 @@ impl SchemaBuilder {
         stored = false,
         fast = false,
         tokenizer_name = TOKENIZER,
-        index_option = RECORD
+        index_option = RECORD,
+        expand_dots_enabled = false
     ))]
     fn add_json_field(
         &mut self,
@@ -342,17 +350,23 @@ impl SchemaBuilder {
         fast: bool,
         tokenizer_name: &str,
         index_option: &str,
+        expand_dots_enabled: bool,
     ) -> PyResult<Self> {
         let builder = &mut self.builder;
-        let options = SchemaBuilder::build_text_option(
+        let text_options = SchemaBuilder::build_text_option(
             stored,
             fast,
             tokenizer_name,
             index_option,
         )?;
 
+        let mut json_options: JsonObjectOptions = text_options.into();
+        if expand_dots_enabled {
+            json_options = json_options.set_expand_dots_enabled();
+        }
+
         if let Some(builder) = builder.write().unwrap().as_mut() {
-            builder.add_json_field(name, options);
+            builder.add_json_field(name, json_options);
         } else {
             return Err(exceptions::PyValueError::new_err(
                 "Schema builder object isn't valid anymore.",

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -637,6 +637,9 @@ impl Searcher {
 
     /// Return the overall number of documents containing
     /// the given term.
+    ///
+    /// `field_name` accepts a JSON subpath the same way `Query.term_query`
+    /// does, e.g. `"attrs.user"`.
     #[pyo3(signature = (field_name, field_value))]
     fn doc_freq(
         &self,

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -73,8 +73,10 @@ class SchemaBuilder:
         self,
         name: str,
         stored: bool = False,
+        fast: bool = False,
         tokenizer_name: str = "default",
         index_option: str = "position",
+        expand_dots_enabled: bool = False,
     ) -> SchemaBuilder:
         pass
 
@@ -230,12 +232,29 @@ class Query:
         field_value: Any,
         index_option: str = "position",
     ) -> Query:
+        """Construct a TermQuery.
+
+        `field_name` accepts a JSON subpath (e.g. "attrs.user") to address a
+        key inside a JSON field. A literal field named "attrs.user" takes
+        precedence over the subpath interpretation. Values are not tokenized.
+
+        For a JSON field, a string `field_value` that parses as a number,
+        bool, or RFC3339 date is interpreted as that typed value - matching
+        how such a value would have been indexed - not as literal text. A
+        JSON string leaf whose content happens to look numeric/bool/date-like
+        (e.g. the string "5") is therefore currently not reachable through
+        `term_query`; `index.parse_query()` can match it because the query
+        parser tries both interpretations, but a single `Term` cannot
+        represent that union.
+        """
         pass
 
     @staticmethod
     def term_set_query(
         schema: Schema, field_name: str, field_values: Sequence[Any]
     ) -> Query:
+        """Construct a TermSetQuery. `field_name` accepts a JSON subpath the
+        same way `term_query` does."""
         pass
 
     @staticmethod
@@ -261,6 +280,8 @@ class Query:
         transposition_cost_one: bool = True,
         prefix=False,
     ) -> Query:
+        """Construct a FuzzyTermQuery. `field_name` accepts a JSON subpath the
+        same way `term_query` does."""
         pass
 
     @staticmethod
@@ -270,6 +291,8 @@ class Query:
         words: list[Union[str, tuple[int, str]]],
         slop: int = 0,
     ) -> Query:
+        """Construct a PhraseQuery. `field_name` accepts a JSON subpath the
+        same way `term_query` does."""
         pass
 
     @staticmethod
@@ -278,6 +301,8 @@ class Query:
         field_name: str,
         words: list[Union[str, tuple[int, str]]],
     ) -> Query:
+        """Construct a PhrasePrefixQuery. `field_name` accepts a JSON subpath
+        the same way `term_query` does."""
         pass
 
     @staticmethod
@@ -437,6 +462,9 @@ class Searcher:
         pass
 
     def doc_freq(self, field_name: str, field_value: Any) -> int:
+        """Return the overall number of documents containing the given term.
+        `field_name` accepts a JSON subpath the same way `Query.term_query`
+        does."""
         pass
 
     def terms_with_prefix(

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -232,12 +232,29 @@ class Query:
         field_value: Any,
         index_option: str = "position",
     ) -> Query:
+        """Construct a TermQuery.
+
+        `field_name` accepts a JSON subpath (e.g. "attrs.user") to address a
+        key inside a JSON field. A literal field named "attrs.user" takes
+        precedence over the subpath interpretation. Values are not tokenized.
+
+        For a JSON field, a string `field_value` that parses as a number,
+        bool, or RFC3339 date is interpreted as that typed value - matching
+        how such a value would have been indexed - not as literal text. A
+        JSON string leaf whose content happens to look numeric/bool/date-like
+        (e.g. the string "5") is therefore currently not reachable through
+        `term_query`; `index.parse_query()` can match it because the query
+        parser tries both interpretations, but a single `Term` cannot
+        represent that union.
+        """
         pass
 
     @staticmethod
     def term_set_query(
         schema: Schema, field_name: str, field_values: Sequence[Any]
     ) -> Query:
+        """Construct a TermSetQuery. `field_name` accepts a JSON subpath the
+        same way `term_query` does."""
         pass
 
     @staticmethod
@@ -263,6 +280,8 @@ class Query:
         transposition_cost_one: bool = True,
         prefix=False,
     ) -> Query:
+        """Construct a FuzzyTermQuery. `field_name` accepts a JSON subpath the
+        same way `term_query` does."""
         pass
 
     @staticmethod
@@ -272,6 +291,8 @@ class Query:
         words: list[Union[str, tuple[int, str]]],
         slop: int = 0,
     ) -> Query:
+        """Construct a PhraseQuery. `field_name` accepts a JSON subpath the
+        same way `term_query` does."""
         pass
 
     @staticmethod
@@ -280,6 +301,8 @@ class Query:
         field_name: str,
         words: list[Union[str, tuple[int, str]]],
     ) -> Query:
+        """Construct a PhrasePrefixQuery. `field_name` accepts a JSON subpath
+        the same way `term_query` does."""
         pass
 
     @staticmethod
@@ -439,6 +462,9 @@ class Searcher:
         pass
 
     def doc_freq(self, field_name: str, field_value: Any) -> int:
+        """Return the overall number of documents containing the given term.
+        `field_name` accepts a JSON subpath the same way `Query.term_query`
+        does."""
         pass
 
     def terms_with_prefix(

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -901,6 +901,308 @@ class TestJsonField:
         # result = index.searcher().search(query, 2)
         # assert len(result.hits) == 1
 
+    def test_json_field_expand_dots_enabled(self):
+        # Without expand_dots, a literal "." in a JSON key is NOT treated as
+        # a path separator - querying it as a path must fail to match, and
+        # the literal key must be reachable only via an escaped dot.
+        plain_schema = SchemaBuilder().add_json_field("attrs", stored=True).build()
+        plain_index = Index(plain_schema)
+        writer = plain_index.writer()
+        doc = Document()
+        doc.add_json("attrs", {"a.b": "hello"})
+        writer.add_document(doc)
+        writer.commit()
+        plain_index.reload()
+
+        query = plain_index.parse_query("attrs.a.b:hello", ["attrs"])
+        result = plain_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        escaped_query = plain_index.parse_query(r"attrs.a\.b:hello", ["attrs"])
+        result = plain_index.searcher().search(escaped_query, 10)
+        assert len(result.hits) == 1
+
+        # With expand_dots enabled, the same flat key "a.b" is treated as a
+        # nested path a -> b, so the unescaped dotted query now matches.
+        expand_schema = (
+            SchemaBuilder()
+            .add_json_field("attrs", stored=True, expand_dots_enabled=True)
+            .build()
+        )
+        expand_index = Index(expand_schema)
+        writer = expand_index.writer()
+        doc = Document()
+        doc.add_json("attrs", {"a.b": "hello"})
+        writer.add_document(doc)
+        writer.commit()
+        expand_index.reload()
+
+        query = expand_index.parse_query("attrs.a.b:hello", ["attrs"])
+        result = expand_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+
+class TestJsonPathTermQueries:
+    @pytest.fixture
+    def json_index(self):
+        schema = (
+            SchemaBuilder()
+            .add_json_field("attrs", stored=True)
+            .add_text_field("title", stored=True)
+            .build()
+        )
+        index = Index(schema)
+        writer = index.writer()
+
+        doc1 = Document()
+        doc1.add_json(
+            "attrs",
+            {
+                "user": "alice",
+                "count": 5,
+                "flag": True,
+                "deep": {"k": "v"},
+                "description": "the best vacuum cleaner ever",
+                "note": "version 5 released",
+                "code": "5",
+                "big": 18446744073709551000,
+                "ts": "2021-01-01T00:00:00.500Z",
+            },
+        )
+        doc1.add_text("title", "alpha")
+        writer.add_document(doc1)
+
+        doc2 = Document()
+        doc2.add_json(
+            "attrs",
+            {
+                "user": "bob",
+                "count": 7,
+                "flag": False,
+                "deep": {"k": "w"},
+                "description": "a mediocre toaster",
+            },
+        )
+        doc2.add_text("title", "beta")
+        writer.add_document(doc2)
+
+        writer.commit()
+        index.reload()
+        return index
+
+    def test_term_query_json_subpath(self, json_index):
+        query = Query.term_query(json_index.schema, "attrs.user", "alice")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.user", "bob")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.user", "carol")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_term_query_nested_json_subpath(self, json_index):
+        query = Query.term_query(json_index.schema, "attrs.deep.k", "v")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_typed_values(self, json_index):
+        # int matches the indexed numeric leaf
+        query = Query.term_query(json_index.schema, "attrs.count", 5)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        # ... and does not match a document with a different numeric value
+        query = Query.term_query(json_index.schema, "attrs.count", 6)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        # str "5" falls back through the same fast-value conversion the
+        # string query parser uses, so it matches the same document as int 5
+        query = Query.term_query(json_index.schema, "attrs.count", "5")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.count", "6")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        # bool
+        query = Query.term_query(json_index.schema, "attrs.flag", True)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.flag", False)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_json_subpath_date_python_datetime(self, json_index):
+        # The indexed value is truncated to whole-second precision by
+        # tantivy's JSON indexer, so a Python datetime with sub-second
+        # precision must be truncated the same way when building the term,
+        # or it can never match what's actually stored.
+        value = datetime.datetime(
+            2021, 1, 1, 0, 0, 0, 500000, tzinfo=datetime.timezone.utc
+        )
+        query = Query.term_query(json_index.schema, "attrs.ts", value)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_json_subpath_date_rfc3339_string(self, json_index):
+        # A string value goes through the same fast-value conversion the
+        # string query parser uses (truncate_date_for_search=True), so a
+        # sub-second RFC3339 string must match the same document.
+        query = Query.term_query(
+            json_index.schema, "attrs.ts", "2021-01-01T00:00:00.500Z"
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_phrase_query_json_subpath(self, json_index):
+        query = Query.phrase_query(
+            json_index.schema, "attrs.description", ["best", "vacuum"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.phrase_query(
+            json_index.schema, "attrs.description", ["vacuum", "best"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_phrase_query_json_subpath_numeric_looking_word(self, json_index):
+        # A phrase word is always text, even when it looks like a number: it
+        # has to match the tokenized text posting, not a typed fast value.
+        query = Query.phrase_query(
+            json_index.schema, "attrs.note", ["version", "5"]
+        )
+        term_hits = {
+            addr.doc for _, addr in json_index.searcher().search(query, 10).hits
+        }
+        assert len(term_hits) == 1
+
+        parsed_q = json_index.parse_query('attrs.note:"version 5"', ["attrs"])
+        parsed_hits = {
+            addr.doc
+            for _, addr in json_index.searcher().search(parsed_q, 10).hits
+        }
+        assert term_hits == parsed_hits
+
+    def test_term_query_json_string_leaf_looking_numeric(self, json_index):
+        # Documented limitation: a single Term can't represent the union the
+        # query parser builds, so a JSON *string* leaf whose content looks
+        # numeric is not reachable via term_query -- the value is interpreted
+        # as the typed number instead.
+        query = Query.term_query(json_index.schema, "attrs.code", "5")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        parsed_q = json_index.parse_query("attrs.code:5", ["attrs"])
+        result = json_index.searcher().search(parsed_q, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_json_subpath_large_u64(self, json_index):
+        # An int above i64::MAX but within u64 must not be routed through f64
+        # (which would round it) -- the JSON indexer stores it as u64.
+        value = 18446744073709551000
+        query = Query.term_query(json_index.schema, "attrs.big", value)
+        term_hits = {
+            addr.doc for _, addr in json_index.searcher().search(query, 10).hits
+        }
+        assert len(term_hits) == 1
+
+        parsed_q = json_index.parse_query(f"attrs.big:{value}", ["attrs"])
+        parsed_hits = {
+            addr.doc
+            for _, addr in json_index.searcher().search(parsed_q, 10).hits
+        }
+        assert term_hits == parsed_hits
+
+    def test_term_query_exact_name_precedence(self):
+        # A real field literally named "a.b" must win over splitting "a.b"
+        # into JSON field "a" with json_path "b".
+        schema = (
+            SchemaBuilder()
+            .add_text_field("a.b", stored=True)
+            .add_json_field("a", stored=True)
+            .build()
+        )
+        index = Index(schema)
+        writer = index.writer()
+
+        doc = Document()
+        # Single-token values, deliberately without punctuation: the default
+        # tokenizer would otherwise split a hyphenated value like
+        # "literal-value" into several terms, which is irrelevant to what
+        # this test checks (field resolution) and would make the assertions
+        # below fail for an unrelated reason.
+        doc.add_text("a.b", "literalvalue")
+        doc.add_json("a", {"b": "jsonvalue"})
+        writer.add_document(doc)
+        writer.commit()
+        index.reload()
+
+        query = Query.term_query(schema, "a.b", "literalvalue")
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(schema, "a.b", "jsonvalue")
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_term_query_unknown_root_raises(self, json_index):
+        with pytest.raises(ValueError):
+            Query.term_query(json_index.schema, "nope.user", "alice")
+
+    def test_term_query_path_on_non_json_field_raises(self, json_index):
+        with pytest.raises(ValueError):
+            Query.term_query(json_index.schema, "title.user", "alice")
+
+    def test_term_query_json_subpath_matches_parse_query(self, json_index):
+        cases = [
+            ("attrs.user", "alice", "attrs.user:alice"),
+            ("attrs.deep.k", "v", "attrs.deep.k:v"),
+            ("attrs.count", 5, "attrs.count:5"),
+            (
+                "attrs.ts",
+                "2021-01-01T00:00:00.500Z",
+                'attrs.ts:"2021-01-01T00:00:00.500Z"',
+            ),
+        ]
+        for field_name, value, query_str in cases:
+            term_q = Query.term_query(json_index.schema, field_name, value)
+            parsed_q = json_index.parse_query(query_str, ["attrs"])
+            term_hits = {
+                addr.doc for _, addr in json_index.searcher().search(term_q, 10).hits
+            }
+            parsed_hits = {
+                addr.doc for _, addr in json_index.searcher().search(parsed_q, 10).hits
+            }
+            assert term_hits == parsed_hits, query_str
+
+    def test_doc_freq_json_subpath(self, json_index):
+        searcher = json_index.searcher()
+        assert searcher.doc_freq("attrs.user", "alice") == 1
+        assert searcher.doc_freq("attrs.user", "carol") == 0
+
+    def test_fuzzy_term_query_json_subpath(self, json_index):
+        # tantivy's FuzzyTermQuery already handles json-path terms natively;
+        # this only needs to confirm the binding passes such a term through.
+        query = Query.fuzzy_term_query(json_index.schema, "attrs.user", "alicee", distance=1)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_fuzzy_term_query_json_subpath_numeric_looking_text(self, json_index):
+        # a JSON string leaf that looks numeric ("code": "5") must still be
+        # matched as text for fuzzy queries, not converted to a typed fast
+        # value (which would make the term un-fuzzy-matchable).
+        query = Query.fuzzy_term_query(json_index.schema, "attrs.code", "5", distance=1)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
 
 @pytest.mark.parametrize("bytes_kwarg", [True, False])
 @pytest.mark.parametrize(

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -942,6 +942,268 @@ class TestJsonField:
         assert len(result.hits) == 1
 
 
+class TestJsonPathTermQueries:
+    @pytest.fixture
+    def json_index(self):
+        schema = (
+            SchemaBuilder()
+            .add_json_field("attrs", stored=True)
+            .add_text_field("title", stored=True)
+            .build()
+        )
+        index = Index(schema)
+        writer = index.writer()
+
+        doc1 = Document()
+        doc1.add_json(
+            "attrs",
+            {
+                "user": "alice",
+                "count": 5,
+                "flag": True,
+                "deep": {"k": "v"},
+                "description": "the best vacuum cleaner ever",
+                "note": "version 5 released",
+                "code": "5",
+                "big": 18446744073709551000,
+                "ts": "2021-01-01T00:00:00.500Z",
+            },
+        )
+        doc1.add_text("title", "alpha")
+        writer.add_document(doc1)
+
+        doc2 = Document()
+        doc2.add_json(
+            "attrs",
+            {
+                "user": "bob",
+                "count": 7,
+                "flag": False,
+                "deep": {"k": "w"},
+                "description": "a mediocre toaster",
+            },
+        )
+        doc2.add_text("title", "beta")
+        writer.add_document(doc2)
+
+        writer.commit()
+        index.reload()
+        return index
+
+    def test_term_query_json_subpath(self, json_index):
+        query = Query.term_query(json_index.schema, "attrs.user", "alice")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.user", "bob")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.user", "carol")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_term_query_nested_json_subpath(self, json_index):
+        query = Query.term_query(json_index.schema, "attrs.deep.k", "v")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_typed_values(self, json_index):
+        # int matches the indexed numeric leaf
+        query = Query.term_query(json_index.schema, "attrs.count", 5)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        # ... and does not match a document with a different numeric value
+        query = Query.term_query(json_index.schema, "attrs.count", 6)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        # str "5" falls back through the same fast-value conversion the
+        # string query parser uses, so it matches the same document as int 5
+        query = Query.term_query(json_index.schema, "attrs.count", "5")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.count", "6")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        # bool
+        query = Query.term_query(json_index.schema, "attrs.flag", True)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.flag", False)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_json_subpath_date_python_datetime(self, json_index):
+        # The indexed value is truncated to whole-second precision by
+        # tantivy's JSON indexer, so a Python datetime with sub-second
+        # precision must be truncated the same way when building the term,
+        # or it can never match what's actually stored.
+        value = datetime.datetime(
+            2021, 1, 1, 0, 0, 0, 500000, tzinfo=datetime.timezone.utc
+        )
+        query = Query.term_query(json_index.schema, "attrs.ts", value)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_json_subpath_date_rfc3339_string(self, json_index):
+        # A string value goes through the same fast-value conversion the
+        # string query parser uses (truncate_date_for_search=True), so a
+        # sub-second RFC3339 string must match the same document.
+        query = Query.term_query(
+            json_index.schema, "attrs.ts", "2021-01-01T00:00:00.500Z"
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_phrase_query_json_subpath(self, json_index):
+        query = Query.phrase_query(
+            json_index.schema, "attrs.description", ["best", "vacuum"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.phrase_query(
+            json_index.schema, "attrs.description", ["vacuum", "best"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_phrase_query_json_subpath_numeric_looking_word(self, json_index):
+        # A phrase word is always text, even when it looks like a number: it
+        # has to match the tokenized text posting, not a typed fast value.
+        query = Query.phrase_query(
+            json_index.schema, "attrs.note", ["version", "5"]
+        )
+        term_hits = {
+            addr.doc for _, addr in json_index.searcher().search(query, 10).hits
+        }
+        assert len(term_hits) == 1
+
+        parsed_q = json_index.parse_query('attrs.note:"version 5"', ["attrs"])
+        parsed_hits = {
+            addr.doc
+            for _, addr in json_index.searcher().search(parsed_q, 10).hits
+        }
+        assert term_hits == parsed_hits
+
+    def test_term_query_json_string_leaf_looking_numeric(self, json_index):
+        # Documented limitation: a single Term can't represent the union the
+        # query parser builds, so a JSON *string* leaf whose content looks
+        # numeric is not reachable via term_query -- the value is interpreted
+        # as the typed number instead.
+        query = Query.term_query(json_index.schema, "attrs.code", "5")
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        parsed_q = json_index.parse_query("attrs.code:5", ["attrs"])
+        result = json_index.searcher().search(parsed_q, 10)
+        assert len(result.hits) == 1
+
+    def test_term_query_json_subpath_large_u64(self, json_index):
+        # An int above i64::MAX but within u64 must not be routed through f64
+        # (which would round it) -- the JSON indexer stores it as u64.
+        value = 18446744073709551000
+        query = Query.term_query(json_index.schema, "attrs.big", value)
+        term_hits = {
+            addr.doc for _, addr in json_index.searcher().search(query, 10).hits
+        }
+        assert len(term_hits) == 1
+
+        parsed_q = json_index.parse_query(f"attrs.big:{value}", ["attrs"])
+        parsed_hits = {
+            addr.doc
+            for _, addr in json_index.searcher().search(parsed_q, 10).hits
+        }
+        assert term_hits == parsed_hits
+
+    def test_term_query_exact_name_precedence(self):
+        # A real field literally named "a.b" must win over splitting "a.b"
+        # into JSON field "a" with json_path "b".
+        schema = (
+            SchemaBuilder()
+            .add_text_field("a.b", stored=True)
+            .add_json_field("a", stored=True)
+            .build()
+        )
+        index = Index(schema)
+        writer = index.writer()
+
+        doc = Document()
+        # Single-token values, deliberately without punctuation: the default
+        # tokenizer would otherwise split a hyphenated value like
+        # "literal-value" into several terms, which is irrelevant to what
+        # this test checks (field resolution) and would make the assertions
+        # below fail for an unrelated reason.
+        doc.add_text("a.b", "literalvalue")
+        doc.add_json("a", {"b": "jsonvalue"})
+        writer.add_document(doc)
+        writer.commit()
+        index.reload()
+
+        query = Query.term_query(schema, "a.b", "literalvalue")
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(schema, "a.b", "jsonvalue")
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_term_query_unknown_root_raises(self, json_index):
+        with pytest.raises(ValueError):
+            Query.term_query(json_index.schema, "nope.user", "alice")
+
+    def test_term_query_path_on_non_json_field_raises(self, json_index):
+        with pytest.raises(ValueError):
+            Query.term_query(json_index.schema, "title.user", "alice")
+
+    def test_term_query_json_subpath_matches_parse_query(self, json_index):
+        cases = [
+            ("attrs.user", "alice", "attrs.user:alice"),
+            ("attrs.deep.k", "v", "attrs.deep.k:v"),
+            ("attrs.count", 5, "attrs.count:5"),
+            (
+                "attrs.ts",
+                "2021-01-01T00:00:00.500Z",
+                'attrs.ts:"2021-01-01T00:00:00.500Z"',
+            ),
+        ]
+        for field_name, value, query_str in cases:
+            term_q = Query.term_query(json_index.schema, field_name, value)
+            parsed_q = json_index.parse_query(query_str, ["attrs"])
+            term_hits = {
+                addr.doc for _, addr in json_index.searcher().search(term_q, 10).hits
+            }
+            parsed_hits = {
+                addr.doc for _, addr in json_index.searcher().search(parsed_q, 10).hits
+            }
+            assert term_hits == parsed_hits, query_str
+
+    def test_doc_freq_json_subpath(self, json_index):
+        searcher = json_index.searcher()
+        assert searcher.doc_freq("attrs.user", "alice") == 1
+        assert searcher.doc_freq("attrs.user", "carol") == 0
+
+    def test_fuzzy_term_query_json_subpath(self, json_index):
+        # tantivy's FuzzyTermQuery already handles json-path terms natively;
+        # this only needs to confirm the binding passes such a term through.
+        query = Query.fuzzy_term_query(json_index.schema, "attrs.user", "alicee", distance=1)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+    def test_fuzzy_term_query_json_subpath_numeric_looking_text(self, json_index):
+        # a JSON string leaf that looks numeric ("code": "5") must still be
+        # matched as text for fuzzy queries, not converted to a typed fast
+        # value (which would make the term un-fuzzy-matchable).
+        query = Query.fuzzy_term_query(json_index.schema, "attrs.code", "5", distance=1)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+
 @pytest.mark.parametrize("bytes_kwarg", [True, False])
 @pytest.mark.parametrize(
     "bytes_payload",

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -967,6 +967,7 @@ class TestJsonPathTermQueries:
                 "code": "5",
                 "big": 18446744073709551000,
                 "ts": "2021-01-01T00:00:00.500Z",
+                "score": 3.5,
             },
         )
         doc1.add_text("title", "alpha")
@@ -1038,6 +1039,43 @@ class TestJsonPathTermQueries:
         result = json_index.searcher().search(query, 10)
         assert len(result.hits) == 1
 
+    def test_term_query_json_subpath_float_whole_number_folding(self, json_index):
+        # A whole-number float must normalize to the same int representation
+        # the JSON indexer folds it to on write, or it can never match the
+        # integer leaf actually stored.
+        query = Query.term_query(json_index.schema, "attrs.count", 5.0)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.count", 6.0)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_term_query_json_subpath_fractional_float(self, json_index):
+        # A non-whole float is kept as a fast f64 value, matching a fractional
+        # JSON leaf exactly.
+        query = Query.term_query(json_index.schema, "attrs.score", 3.5)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_query(json_index.schema, "attrs.score", 3.6)
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_term_query_json_subpath_non_finite_float(self, json_index):
+        # tantivy's JSON indexer silently drops a non-finite float leaf --
+        # never writing a term for it -- so a term built from one here could
+        # never match anything indexed. This must raise rather than silently
+        # building an unmatchable term.
+        with pytest.raises(ValueError):
+            Query.term_query(json_index.schema, "attrs.count", float("nan"))
+
+        with pytest.raises(ValueError):
+            Query.term_query(json_index.schema, "attrs.count", float("inf"))
+
+        with pytest.raises(ValueError):
+            Query.term_query(json_index.schema, "attrs.count", float("-inf"))
+
     def test_term_query_json_subpath_date_python_datetime(self, json_index):
         # The indexed value is truncated to whole-second precision by
         # tantivy's JSON indexer, so a Python datetime with sub-second
@@ -1090,6 +1128,32 @@ class TestJsonPathTermQueries:
             for _, addr in json_index.searcher().search(parsed_q, 10).hits
         }
         assert term_hits == parsed_hits
+
+    def test_phrase_prefix_query_json_subpath(self, json_index):
+        query = Query.phrase_prefix_query(
+            json_index.schema, "attrs.description", ["best", "vac"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.phrase_prefix_query(
+            json_index.schema, "attrs.description", ["best", "toa"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+    def test_term_set_query_json_subpath(self, json_index):
+        query = Query.term_set_query(
+            json_index.schema, "attrs.user", ["alice", "carol"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
+        query = Query.term_set_query(
+            json_index.schema, "attrs.user", ["alice", "bob"]
+        )
+        result = json_index.searcher().search(query, 10)
+        assert len(result.hits) == 2
 
     def test_term_query_json_string_leaf_looking_numeric(self, json_index):
         # Documented limitation: a single Term can't represent the union the
@@ -1187,6 +1251,43 @@ class TestJsonPathTermQueries:
         searcher = json_index.searcher()
         assert searcher.doc_freq("attrs.user", "alice") == 1
         assert searcher.doc_freq("attrs.user", "carol") == 0
+
+    def test_term_query_json_subpath_expand_dots_enabled(self):
+        # A literal "." in a JSON key is only treated as a nested path
+        # separator by term_query when expand_dots_enabled is set on the
+        # field -- this exercises that option through term_query itself,
+        # not just through the string query parser.
+        plain_schema = (
+            SchemaBuilder().add_json_field("attrs", stored=True).build()
+        )
+        plain_index = Index(plain_schema)
+        writer = plain_index.writer()
+        doc = Document()
+        doc.add_json("attrs", {"a.b": "hello"})
+        writer.add_document(doc)
+        writer.commit()
+        plain_index.reload()
+
+        query = Query.term_query(plain_index.schema, "attrs.a.b", "hello")
+        result = plain_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        expand_schema = (
+            SchemaBuilder()
+            .add_json_field("attrs", stored=True, expand_dots_enabled=True)
+            .build()
+        )
+        expand_index = Index(expand_schema)
+        writer = expand_index.writer()
+        doc = Document()
+        doc.add_json("attrs", {"a.b": "hello"})
+        writer.add_document(doc)
+        writer.commit()
+        expand_index.reload()
+
+        query = Query.term_query(expand_index.schema, "attrs.a.b", "hello")
+        result = expand_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
 
     def test_fuzzy_term_query_json_subpath(self, json_index):
         # tantivy's FuzzyTermQuery already handles json-path terms natively;


### PR DESCRIPTION
## Summary

Related to #434 â€” that issue asks about fuzzy matching over an entire JSON document the way you would a text field; this PR delivers fuzzy (and other term-based) matching on a specific, named JSON subpath, which is narrower.

`Query.term_query(schema, "notes.user", "alice")` currently raises `ValueError: Field 'notes.user' is not defined in the schema.` even when `notes` is a JSON field containing a `user` key â€” the only way to query a JSON subpath today is the string query parser (`index.parse_query("notes.user:alice")`). This PR brings the programmatic `Query` constructors closer to what the parser can already do for this case, though it isn't full parity â€” see the two gaps called out below.

- `Query.term_query`, `term_set_query`, `phrase_query`, `phrase_prefix_query`, `fuzzy_term_query`, and `Searcher.doc_freq` now accept a JSON subpath as `field_name` (e.g. `"attrs.user"`).
- `make_term` resolves `field_name` via `Schema::find_field` instead of an exact-name-only lookup. A field literally named `"attrs.user"` still takes precedence over the subpath interpretation (this is `find_field`'s own resolution order).
- For a JSON subpath, the Python value is typed the way tantivy's own JSON indexing path types a JSON leaf: a string is tried as a fast numeric/bool/date value before falling back to text, floats and out-of-`i64`-range ints are normalized/widened to match what the JSON indexer actually stores, and dates are truncated to search precision. Phrase words and fuzzy-query values on a JSON subpath are always treated as text, never as typed fast values, matching how the parser only ever tokenizes phrase content.
- Also exposes `JsonObjectOptions::set_expand_dots_enabled()` on `SchemaBuilder.add_json_field` (not previously reachable from Python at all) â€” needed to exercise the `expand_dots`-enabled path in tests.
- Two known, documented gaps versus the string query parser:
  - A JSON string leaf whose text looks numeric/bool/date (e.g. `"5"`) is not reachable via `term_query`. The query parser builds an OR of the fast-value term and the text term for this case; a single `Term` can't represent that union. Documented on `term_query`'s docstring and in the tutorial, with `index.parse_query()` given as the workaround.
  - `term_query` does not tokenize its input the way the parser does â€” it takes the value as-is, consistent with `term_query`'s existing "not tokenized, pre-tokenize yourself" contract for non-JSON fields. This is intentional, not a bug, but it means a `term_query` value and a `parse_query` string aren't always interchangeable even when both resolve to the same field.

Motivation: `paperless-ngx` builds tantivy queries programmatically, constructing an AST of `Query` objects rather than a query string â€” this keeps parity with how its search layer worked under the older Whoosh library, which it's migrating off of. Whoosh's query builder gave fine-grained, predictable control over how each search term was constructed, and reproducing that as closely as possible minimizes the risk of subtly changing what users' existing searches match as part of the migration â€” a difference in how a query string gets parsed is a much easier way to accidentally break someone's saved search than an explicitly constructed term. JSON-subpath terms were the one leaf type that still forced a fallback to the string parser, reintroducing exactly that risk.

## AI disclosure

Per CONTRIBUTING.md's AI policy: this PR was built with AI assistance (Claude, via Claude Code), including a multi-pass review step that caught and fixed a few real bugs (date-truncation precision, phrase queries mistyping numeric-looking words, a missing NaN/inf guard on the float-normalization path) before and during review. I've read through the diff and understand the changes â€” happy to discuss any part of it.

## Test plan

- [x] `cargo fmt --check` passes
- [x] Full pytest suite passes
- [x] New tests cover: basic and nested JSON subpath term queries, typed values (int/str-fallback/bool/date/u64-range-int/whole-number float folding/fractional float/non-finite float rejection), phrase queries (including a numeric-looking phrase word), phrase-prefix queries, term-set queries, exact-name-over-subpath precedence, unknown-root and non-JSON-field-path error cases, the documented numeric-looking-string-leaf limitation (0 hits via `term_query` vs. 1 via `parse_query`), parity against `index.parse_query()` for equivalent queries, `Searcher.doc_freq`, `fuzzy_term_query` on a JSON subpath (including a numeric-looking value), and `expand_dots_enabled` exercised through both `parse_query` and `term_query` directly
- [x] Manually verified the previously-broken scenario (`Query.term_query(schema, "notes.user", "alice")` on a JSON field) now works as expected

- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.


