### PR TITLE
feat: expose expand_dots_enabled on SchemaBuilder.add_json_field

### DIFF
--- a/src/schemabuilder.rs
+++ b/src/schemabuilder.rs
@@ -5,7 +5,7 @@ use pyo3::{exceptions, prelude::*};
 use crate::schema::Schema;
 use std::sync::{Arc, RwLock};
 use tantivy::schema::{
-    self, BytesOptions, DateOptions, IpAddrOptions, INDEXED,
+    self, BytesOptions, DateOptions, IpAddrOptions, JsonObjectOptions, INDEXED,
 };
 
 /// Tantivy has a very strict schema.
@@ -325,6 +325,13 @@ impl SchemaBuilder {
     ///         document id and the term frequency, while the 'position' option
     ///         records the document id, term frequency and the positions of
     ///         the term occurrences in the document.
+    ///     expand_dots_enabled (bool, optional): If true, a "." in a JSON
+    ///         object key is treated as a path separator, the same as a "."
+    ///         between keys in a query string or in `field_name` passed to
+    ///         `Query.term_query`. E.g. `{"a.b": "hello"}` is then indexed as
+    ///         if it was `{"a": {"b": "hello"}}`, reachable via `attrs.a.b`
+    ///         instead of the default `attrs.a\.b` escaped form. Defaults to
+    ///         False.
     ///
     /// Returns the associated field handle.
     /// Raises a ValueError if there was an error with the field creation.
@@ -333,7 +340,8 @@ impl SchemaBuilder {
         stored = false,
         fast = false,
         tokenizer_name = TOKENIZER,
-        index_option = RECORD
+        index_option = RECORD,
+        expand_dots_enabled = false
     ))]
     fn add_json_field(
         &mut self,
@@ -342,17 +350,23 @@ impl SchemaBuilder {
         fast: bool,
         tokenizer_name: &str,
         index_option: &str,
+        expand_dots_enabled: bool,
     ) -> PyResult<Self> {
         let builder = &mut self.builder;
-        let options = SchemaBuilder::build_text_option(
+        let text_options = SchemaBuilder::build_text_option(
             stored,
             fast,
             tokenizer_name,
             index_option,
         )?;
 
+        let mut json_options: JsonObjectOptions = text_options.into();
+        if expand_dots_enabled {
+            json_options = json_options.set_expand_dots_enabled();
+        }
+
         if let Some(builder) = builder.write().unwrap().as_mut() {
-            builder.add_json_field(name, options);
+            builder.add_json_field(name, json_options);
         } else {
             return Err(exceptions::PyValueError::new_err(
                 "Schema builder object isn't valid anymore.",

--- a/tantivy/tantivy.pyi
+++ b/tantivy/tantivy.pyi
@@ -73,8 +73,10 @@ class SchemaBuilder:
         self,
         name: str,
         stored: bool = False,
+        fast: bool = False,
         tokenizer_name: str = "default",
         index_option: str = "position",
+        expand_dots_enabled: bool = False,
     ) -> SchemaBuilder:
         pass
 

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -901,6 +901,46 @@ class TestJsonField:
         # result = index.searcher().search(query, 2)
         # assert len(result.hits) == 1
 
+    def test_json_field_expand_dots_enabled(self):
+        # Without expand_dots, a literal "." in a JSON key is NOT treated as
+        # a path separator - querying it as a path must fail to match, and
+        # the literal key must be reachable only via an escaped dot.
+        plain_schema = SchemaBuilder().add_json_field("attrs", stored=True).build()
+        plain_index = Index(plain_schema)
+        writer = plain_index.writer()
+        doc = Document()
+        doc.add_json("attrs", {"a.b": "hello"})
+        writer.add_document(doc)
+        writer.commit()
+        plain_index.reload()
+
+        query = plain_index.parse_query("attrs.a.b:hello", ["attrs"])
+        result = plain_index.searcher().search(query, 10)
+        assert len(result.hits) == 0
+
+        escaped_query = plain_index.parse_query(r"attrs.a\.b:hello", ["attrs"])
+        result = plain_index.searcher().search(escaped_query, 10)
+        assert len(result.hits) == 1
+
+        # With expand_dots enabled, the same flat key "a.b" is treated as a
+        # nested path a -> b, so the unescaped dotted query now matches.
+        expand_schema = (
+            SchemaBuilder()
+            .add_json_field("attrs", stored=True, expand_dots_enabled=True)
+            .build()
+        )
+        expand_index = Index(expand_schema)
+        writer = expand_index.writer()
+        doc = Document()
+        doc.add_json("attrs", {"a.b": "hello"})
+        writer.add_document(doc)
+        writer.commit()
+        expand_index.reload()
+
+        query = expand_index.parse_query("attrs.a.b:hello", ["attrs"])
+        result = expand_index.searcher().search(query, 10)
+        assert len(result.hits) == 1
+
 
 @pytest.mark.parametrize("bytes_kwarg", [True, False])
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Split out from #716 per @wallies's review comment there: `JsonObjectOptions::set_expand_dots_enabled()` is public upstream but was never wired into the Python `SchemaBuilder.add_json_field` API. This is a plain binding gap, unrelated to the JSON-subpath term-query work in #716, so it's landing on its own.

- Adds an `expand_dots_enabled` (default `False`) keyword argument to `SchemaBuilder.add_json_field`.
- When set, a `.` in a JSON object key is treated as a path separator — e.g. `{"a.b": "hello"}` becomes queryable as `attrs.a.b` instead of the default escaped `attrs.a\.b` form — matching how `.` already separates path segments in query strings and `Term`s.
- Updates the `tantivy.pyi` stub for `add_json_field` (also fixes a pre-existing gap where `fast` was missing from the stub, noted separately in the #716 review).

## AI disclosure

Per CONTRIBUTING.md's AI policy: the code and test here originated in #716, which was AI-generated (Claude, via Claude Code). I extracted this specific change onto its own branch at @wallies's suggestion; the diff itself is unmodified from #716.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `test_json_field_expand_dots_enabled` covers both the disabled (default, escaped-dot) and enabled (unescaped dotted-path) behavior via `index.parse_query()`

- [x] I have read the [contributing guidelines](https://github.com/quickwit-oss/tantivy-py/blob/master/CONTRIBUTING.md) which also contains information about our AI policy.